### PR TITLE
build: allow building from local electron/electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Website
+# electronjs.org-new
 
-This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
+This repository contains the code for the new electronsjs.org website. It is built using
+[Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
 
 ## Installation
 
@@ -10,11 +11,38 @@ yarn install
 
 ## Local Development
 
+If you want to use the contents from [`electron/electron`](https://github.com/electron/electron)
+run the following:
+
 ```console
+yarn prebuid
 yarn start
 ```
 
-This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
+If you want the website to pick your local documentation, run:
+
+```console
+yarn prebuild ../relative/path/to/local/electron/repo
+yarn start
+```
+
+For example, if you have the following structure:
+
+```
+└── projects
+     ├─ electron
+     ├─ electronjs.org-new
+     ├─ ...
+```
+
+and assuming your prompt is in `/projects/electronjs.org-new/` you will have to run:
+
+```console
+yarn prebuild ../electron
+yarn start
+```
+
+`yarn start` starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
 
 ## Build
 
@@ -23,11 +51,3 @@ yarn build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-## Deployment
-
-```console
-GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.

--- a/scripts/pre-build.js
+++ b/scripts/pre-build.js
@@ -8,31 +8,47 @@
 const path = require('path');
 const del = require('del');
 
-const { download } = require('./tasks/download-docs');
+const { copy, download } = require('./tasks/download-docs');
 const { addFrontmatter } = require('./tasks/add-frontmatter');
 const { createSidebar } = require('./tasks/create-sidebar');
 const { fixContent } = require('./tasks/md-fixers');
+const { existsSync, fstat } = require('fs');
 
 const DOCS_FOLDER = 'docs';
 const BLOG_FOLDER = 'blog';
 // TODO: Figure out the latest release
 const VERSION = '12-x-y';
 
-const start = async () => {
+/**
+ *
+ * @param {string} localElectron
+ */
+const start = async (localElectron) => {
   console.log(`Deleting previous content`);
   await del(DOCS_FOLDER);
   // TODO: Uncomment once we have the blog up and running
   // await del(BLOG_FOLDER);
 
-  console.log(`Downloading docs for "v${VERSION}"`);
-  await download({
-    target: VERSION,
-    repository: 'electron',
-    destination: DOCS_FOLDER,
-    downloadMatch: 'docs',
-  });
+  if (!localElectron) {
+    console.log(`Downloading docs for "v${VERSION}"`);
+    await download({
+      target: VERSION,
+      repository: 'electron',
+      destination: DOCS_FOLDER,
+      downloadMatch: 'docs',
+    });
+  } else if (existsSync(localElectron)) {
+    await copy({
+      target: localElectron,
+      destination: DOCS_FOLDER,
+      downloadMatch: 'docs',
+    });
+  } else {
+    console.error(`Path ${localElectron} does not exist`);
+    return process.exit(-1);
+  }
 
-  // TODO: Uncomment once we have the blog up and running
+  // TODO: Uncoment once we have the blog enabled
   // console.log(`Downloading posts`);
   // await download({
   //   target: 'master',
@@ -51,4 +67,4 @@ const start = async () => {
   await createSidebar(DOCS_FOLDER, path.join(process.cwd(), 'sidebars.js'));
 };
 
-start();
+start(process.argv[2]);


### PR DESCRIPTION
This PR allows developers to pass a parameter to indicate where in the
file system the `prebuild` script should look for the documentation. It
assumes it is a clone of `electron/electron` so the content should be
under a `/docs` folder. E.g.:

```console
yarn prebuild ../electron
```

In the future there might be a `watch` option enabled by default. This
is the MVP for #4.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #4