### PR TITLE
feat: add `create-electron-documentation` package

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,11 +7,20 @@
     {
       "type": "pwa-node",
       "request": "launch",
-      "name": "Launch Program",
+      "name": "Prebuild",
       "skipFiles": ["<node_internals>/**"],
       "program": "${workspaceFolder}/scripts/pre-build.js",
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "Create documentation",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/create-electron-documentation/index.js",
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}/docs/how-to"
     }
   ]
 }

--- a/create-electron-documentation/index.js
+++ b/create-electron-documentation/index.js
@@ -1,0 +1,175 @@
+//@ts-check
+
+const fs = require('fs').promises;
+const { existsSync } = require('fs');
+const path = require('path');
+
+const loadContent = (route) => {
+  const finalPath = path.join(__dirname, route);
+
+  return fs.readFile(finalPath, 'utf-8');
+};
+
+/**
+ * Loads the templates required to create a new Electron guide
+ */
+const loadTemplates = async () => {
+  const templatePaths = [
+    {
+      content: await loadContent('./templates/documentation.md'),
+      destination: './${slug}.md',
+    },
+    {
+      content: await loadContent('./templates/fiddle/index.html'),
+      destination: '/fiddles/${slug}/index.html',
+    },
+    {
+      content: await loadContent('./templates/fiddle/main.js'),
+      destination: '/fiddles/${slug}/main.js',
+    },
+    {
+      content: await loadContent('./templates/fiddle/preload.js'),
+      destination: '/fiddles/${slug}/preload.js',
+    },
+    {
+      content: await loadContent('./templates/fiddle/renderer.js'),
+      destination: '/fiddles/${slug}/renderer.js',
+    },
+  ];
+
+  return templatePaths;
+};
+
+/**
+ *
+ * @param {string} content
+ * @param {{key: string;value: string;}[]} values
+ * @returns
+ */
+const interpolate = (content, values) => {
+  let interpolated = content;
+  for (const { key, value } of values) {
+    interpolated = interpolated.replace(
+      new RegExp(`\\$\\{${key}\\}`, 'g'),
+      value
+    );
+  }
+
+  return interpolated;
+};
+
+/**
+ * Naively creates all the necessary folders for the given `route`.
+ * @param {string} route The route to create, has to be absolute and no filename
+ */
+const mkdirp = async (route) => {
+  if (existsSync(route)) {
+    return;
+  }
+
+  const parent = path.dirname(route);
+
+  if (!existsSync(parent)) {
+    await mkdirp(parent);
+  }
+
+  await fs.mkdir(route);
+};
+
+/**
+ * Writes the files interpolating the different values
+ * @param {{content: string;destination: string;}[]} templates
+ * @param {{key: string; value: string;}[]} information
+ * @param {string} docsRoot
+ */
+const writeFiles = async (templates, information, docsRoot) => {
+  const createdFiles = [];
+  for (const { destination, content } of templates) {
+    const finalContent = interpolate(content, information);
+    const root = destination.startsWith('/') ? docsRoot : process.cwd();
+    const finalDestination = path.join(
+      root,
+      interpolate(destination, information)
+    );
+
+    await mkdirp(path.dirname(finalDestination));
+
+    await fs.writeFile(finalDestination, finalContent, 'utf-8');
+
+    createdFiles.push(finalDestination);
+  }
+
+  return createdFiles;
+};
+
+/**
+ * Listens for stdin and returns the first line of text received.
+ * @returns {Promise<string>}
+ */
+const getInput = () => {
+  return new Promise((resolve) => {
+    process.stdin.addListener('data', function (data) {
+      const input = data.toString().trim();
+      if (input.length > 0) {
+        process.stdin.removeAllListeners('data');
+        resolve(input);
+      }
+    });
+  });
+};
+
+/** Returns the absolute path to `docs`. */
+const getDocsRoot = () => {
+  const current = process.cwd();
+  const docs = `${path.sep}docs${path.sep}`;
+  if (current.includes(docs)) {
+    const parts = current.split(docs);
+    return path.join(parts[0], 'docs');
+  }
+
+  return '';
+};
+
+const start = async () => {
+  const docsRoot = getDocsRoot();
+
+  if (!docsRoot) {
+    console.error(
+      'Please execute this command in one of the folders under the electron documentation (e.g.: electron/electron/docs/tutorial)'
+    );
+    process.exitCode = 1;
+
+    return;
+  }
+
+  console.log(
+    'Welcome to the Electron documentation generator. Please answer the following questions:'
+  );
+  console.log(`Title:`);
+
+  const title = await getInput();
+
+  console.log(`Description:`);
+
+  const description = await getInput();
+
+  const information = [
+    { key: 'title', value: title },
+    { key: 'description', value: description },
+    { key: 'slug', value: title.toLowerCase().replace(/\s/g, '-') },
+  ];
+
+  const templates = await loadTemplates();
+
+  const createdFiles = await writeFiles(templates, information, docsRoot);
+
+  console.log(`The following files have been created:`);
+  for (const file of createdFiles) {
+    console.log(`  - ${file}`);
+  }
+
+  // Need to pause reading so the process exists correctly
+  process.stdin.pause();
+};
+
+start();

--- a/create-electron-documentation/package.json
+++ b/create-electron-documentation/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "create-electron-documentation",
+  "version": "0.0.1",
+  "description": "Generator to easily create new documentation pages for Electron with code examples.",
+  "repository": {
+    "url": "https://github.com/electron/electronjs.org-new/tree/main/create-electron-documentation"
+  },
+  "main": "index.js",
+  "author": "molant",
+  "license": "Apache-2.0"
+}

--- a/create-electron-documentation/readme.md
+++ b/create-electron-documentation/readme.md
@@ -1,0 +1,35 @@
+# `create-electron-documentation`
+
+The goal of this package is to help developers create the scaffolding
+for [Electron] examples faster.
+
+## How to use it?
+
+Electron's documentation is under the `/docs` folder of the [main repo].
+You will have to clone it locally and call the following script from one
+of the folders under `/docs` (e.g.: [`/docs/tutorial`][tutorials]):
+
+```console
+npm create electron-documentation
+```
+
+The script will ask you only 2 things that cannot be empty strings:
+
+- Title
+- Description
+
+Once executed, the following files will be created:
+
+- A markdown file `the-provided-title.md` in the folder you invoked the script
+- A new folder under `/docs/fiddles/the-provided-title` with a minimum [fiddle]
+  example for your documentation following good practices.
+
+At this point, feel free to modify any of them or move the fiddle somewhere
+else (but remember to update the reference in the markdown file!).
+
+Thanks for contributing to Electron!
+
+[electron]: https://www.electronjs.org
+[fiddle]: https://www.electronjs.org/fiddle
+[main repo]: https://github.com/electron/electron
+[tutorials]: https://github.com/electron/electron/tree/master/docs/tutorial

--- a/create-electron-documentation/readme.md
+++ b/create-electron-documentation/readme.md
@@ -13,10 +13,15 @@ of the folders under `/docs` (e.g.: [`/docs/tutorial`][tutorials]):
 npm create electron-documentation
 ```
 
-The script will ask you only 2 things that cannot be empty strings:
+The script will prompt you to enter the documentation page title and description:
 
-- Title
-- Description
+```console
+> npm create electron-documentation
+> Title:
+> my-new-doc-page
+> Description:
+> A description for my new doc page
+```
 
 Once executed, the following files will be created:
 

--- a/create-electron-documentation/templates/documentation.md
+++ b/create-electron-documentation/templates/documentation.md
@@ -20,9 +20,17 @@ ${description}
     add new ones, etc.
 -->
 
-```fiddle docs/fiddles/${slug}
+<!--
+    Because Electron examples usually require multiple files (HTML, CSS, JS
+    for the main and renderer process, etc.), we use this custom code block
+    for Fiddle (https://www.electronjs.org/fiddle).
+    Please modify any of the files in the referenced folder to fit your
+    example.
+    The content in this codeblock will not be rendered in the website so you
+    can leave it empty.
+-->
 
-Your code here
+```fiddle docs/fiddles/${slug}
 
 ```
 

--- a/create-electron-documentation/templates/documentation.md
+++ b/create-electron-documentation/templates/documentation.md
@@ -1,0 +1,29 @@
+---
+title: ${title}
+description: ${description}
+slug: ${slug}
+hide_title: true
+---
+
+# ${title}
+
+## Overview
+
+<!-- ✍ Update this section if you want to provide more details -->
+
+${description}
+
+### Examples
+
+<!--
+    ✍ Feel free to rename this section,
+    add new ones, etc.
+-->
+
+```fiddle docs/fiddles/${slug}
+
+Your code here
+
+```
+
+<!-- ✍ Explanation of the code below -->

--- a/create-electron-documentation/templates/fiddle/index.html
+++ b/create-electron-documentation/templates/fiddle/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8" />
+    <title>${title}</title>
+  </head>
+
+  <body>
+    <div>
+      <h1>${title}</h1>
+
+      <h3>${description}</h3>
+
+      <div>
+        <!-- ✍ The example should probably go around here -->
+
+        <button id="hello">Say hello 👋</button>
+        <p id="answer"></p>
+      </div>
+
+    <div>
+
+    <script src="renderer.js"></script>
+  </body>
+</html>

--- a/create-electron-documentation/templates/fiddle/main.js
+++ b/create-electron-documentation/templates/fiddle/main.js
@@ -1,0 +1,50 @@
+// Modules to control application life and create native browser window
+const path = require('path');
+const { app, BrowserWindow, ipcMain } = require('electron');
+
+function createWindow() {
+  // Create the browser window.
+  const mainWindow = new BrowserWindow({
+    webPreferences: {
+      sandbox: true,
+      preload: path.join(app.getAppPath(), 'preload.js'),
+    },
+  });
+
+  // and load the index.html of the app.
+  mainWindow.loadFile('index.html');
+
+  // Open the DevTools.
+  // mainWindow.webContents.openDevTools()
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.whenReady().then(createWindow);
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function () {
+  // On macOS it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', function () {
+  // On macOS it is common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (BrowserWindow.getAllWindows().length === 0) createWindow();
+});
+
+ipcMain.handle('say-hello', async (event, ...args) => {
+  // You can execute async code here
+  // const result = await somePromise(...args)
+  // return result
+
+  return 'Hello from main 👋';
+});
+
+// In this file you can include the rest of your app's specific main process
+// code. You can also put them in separate files and require them here.

--- a/create-electron-documentation/templates/fiddle/preload.js
+++ b/create-electron-documentation/templates/fiddle/preload.js
@@ -1,0 +1,9 @@
+// This file is loaded whenever a javascript context is created. It runs in a
+// private scope that can access a subset of Electron renderer APIs. Without
+// contextIsolation enabled, it's possible to accidentally leak privileged
+// globals like ipcRenderer to web content.
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('myAPI', {
+  sayHello: () => ipcRenderer.invoke('say-hello'),
+});

--- a/create-electron-documentation/templates/fiddle/renderer.js
+++ b/create-electron-documentation/templates/fiddle/renderer.js
@@ -1,0 +1,10 @@
+(() => {
+  const button = document.getElementById('hello');
+  const answer = document.getElementById('answer');
+
+  button.addEventListener('click', async () => {
+    // `myAPI.sayHello()` is defined in `preload.js`
+    const response = await myAPI.sayHello();
+    answer.textContent = response;
+  });
+})();


### PR DESCRIPTION
Add the code for the package `create-electron-documentation` to help
writers of Electron documentation scaffold their examples faster and
following good patterns (using `sandbox` and `contextBridge`).

Once published the developers will use it by calling

```console
npm create electron-documentation
```

From a folder under the main Electron documentation folder.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #12

https://user-images.githubusercontent.com/606594/116306611-208def00-a75a-11eb-8849-fc789b83b357.mp4


