### PR TITLE
fix: bin info in `create-electron-documentation`

### DIFF
--- a/create-electron-documentation/index.js
+++ b/create-electron-documentation/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 //@ts-check
 
 const fs = require('fs').promises;

--- a/create-electron-documentation/package.json
+++ b/create-electron-documentation/package.json
@@ -1,7 +1,8 @@
 {
   "name": "create-electron-documentation",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Generator to easily create new documentation pages for Electron with code examples.",
+  "bin": "./index.js",
   "repository": {
     "url": "https://github.com/electron/electronjs.org-new/tree/main/create-electron-documentation"
   },


### PR DESCRIPTION
Without the `bin` property in `package.json` and `#!` at the top of
`index.js` the command `npm create electron-documenation` does not
work properly.