### PR TITLE
feat: enable docsearch

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,6 +79,11 @@ module.exports = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} My Project, Inc. Built with Docusaurus.`,
     },
+    algolia: {
+      apiKey: 'f9fb1d51a99fc479d5979cfa2aae48b9',
+      indexName: 'beta-electronjs',
+      contextualSearch: true,
+    },
   },
   presets: [
     [


### PR DESCRIPTION
Enable docsearch module with provided configuration by algolia.

Currently the search does not seem to work when `contextSearch` is
enabled. This seems to be a temporary issue per Clement's mail:

> As the DocSearch plugin is not active yet, you won't be able to use
the Docusaurus `contextualSearch` option until next crawl.

While this feature is not necessary (there are no versioned docs),
it seems like the search results page has it enabled by default
always ([1]) so might as well have it enabled everywhere to make sure it
works.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

[1]: https://github.com/temporalio/documentation/pull/357/files#r616656533
Ref: https://github.com/facebook/docusaurus/issues/3805
Part of #2