### PR TITLE
build: enable CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    name: Install & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install dependencies
+        uses: bahmutov/npm-install@HEAD
+
+      - name: Test
+        run: yarn test
+        env:
+          CI: true

--- a/scripts/tasks/create-sidebar.js
+++ b/scripts/tasks/create-sidebar.js
@@ -5,11 +5,7 @@ const { existsSync } = require('fs');
 const { stringify } = require('json5');
 const globby = require('globby');
 
-const IGNORE_LIST = [
-  'api/locales',
-  'api/remote',
-  'api/synopsis',
-];
+const IGNORE_LIST = ['api/locales', 'api/remote', 'api/synopsis'];
 
 /**
  * @typedef Entry


### PR DESCRIPTION
Enables CI via GitHub actions. Additionally it uses the action
`bahmutov/npm-install` to reduce the process of installing
dependencies by ~40%.