### PR TITLE
feat: add "Examples" navigation link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -32,6 +32,12 @@ module.exports = {
           position: 'left',
         },
         {
+          label: 'Examples',
+          type: 'doc',
+          docId: 'how-to/examples',
+          position: 'left',
+        },
+        {
           href: 'https://github.com/electron/electron',
           label: 'GitHub',
           position: 'right',

--- a/scripts/pre-build.js
+++ b/scripts/pre-build.js
@@ -15,6 +15,7 @@ const { copy, download } = require('./tasks/download-docs');
 const { addFrontmatter } = require('./tasks/add-frontmatter');
 const { createSidebar } = require('./tasks/create-sidebar');
 const { fixContent } = require('./tasks/md-fixers');
+const { copyNewContent } = require('./tasks/copy-new-content');
 
 const DOCS_FOLDER = 'docs';
 // const BLOG_FOLDER = 'blog';
@@ -62,6 +63,9 @@ const start = async (localElectron) => {
   //   destination: BLOG_FOLDER,
   //   downloadMatch: 'data/blog',
   // });
+
+  console.log('Copying new content');
+  await copyNewContent(DOCS_FOLDER);
 
   console.log('Fixing markdown');
   await fixContent(DOCS_FOLDER);

--- a/scripts/tasks/copy-new-content.js
+++ b/scripts/tasks/copy-new-content.js
@@ -1,0 +1,21 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const newContent = new Map([['how-to-examples.md', 'how-to/examples.md']]);
+
+/**
+ * Copies the new content files to the destination
+ * @param {string} destination
+ */
+const copyNewContent = async (destination) => {
+  for (const [source, target] of newContent) {
+    await fs.copyFile(
+      path.join(__dirname, source),
+      path.join(destination, target)
+    );
+  }
+};
+
+module.exports = {
+  copyNewContent,
+};

--- a/scripts/tasks/how-to-examples.md
+++ b/scripts/tasks/how-to-examples.md
@@ -1,0 +1,38 @@
+---
+title: 'Examples'
+description: 'Electron examples directly for you to use'
+slug: examples
+hide_title: false
+---
+
+# Examples
+
+In this section we have documented some of the most popular things developers do
+in their Electron applications. The easiest way to run the examples is using
+[Fiddle][fiddle]. To do this, first you will have to download and install the
+right version for your Operating System from [here][fiddle].
+
+Once you have done this, you can press on the "Open in Fiddle" button that you
+will find below code samples like the following one:
+
+```fiddle docs/fiddles/quick-start
+window.addEventListener('DOMContentLoaded', () => {
+  const replaceText = (selector, text) => {
+    const element = document.getElementById(selector)
+    if (element) element.innerText = text
+  }
+
+  for (const type of ['chrome', 'node', 'electron']) {
+    replaceText(`${type}-version`, process.versions[type])
+  }
+})
+```
+
+## How to...?
+
+The following are all the "How to?" available at the moment (you can access them
+from the sidebar as well). If there is something that you would like to do that
+is not documented, please join our [discord server][] and let us know!
+
+[discord server]: https://discord.com/invite/electron
+[fiddle]: https://www.electronjs.org/fiddle

--- a/scripts/tasks/how-to-examples.md
+++ b/scripts/tasks/how-to-examples.md
@@ -30,9 +30,9 @@ window.addEventListener('DOMContentLoaded', () => {
 
 ## How to...?
 
-The following are all the "How to?" available at the moment (you can access them
-from the sidebar as well). If there is something that you would like to do that
-is not documented, please join our [discord server][] and let us know!
+You can find the full list of "How to?" in the sidebar. If there is
+something that you would like to do that is not documented, please join
+our [discord server][] and let us know!
 
 [discord server]: https://discord.com/invite/electron
 [fiddle]: https://www.electronjs.org/fiddle

--- a/scripts/tasks/how-to-examples.md
+++ b/scripts/tasks/how-to-examples.md
@@ -32,7 +32,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
 You can find the full list of "How to?" in the sidebar. If there is
 something that you would like to do that is not documented, please join
-our [discord server][] and let us know!
+our [Discord server][] and let us know!
 
-[discord server]: https://discord.com/invite/electron
+[Discord server]: https://discord.com/invite/electron
 [fiddle]: https://www.electronjs.org/fiddle

--- a/scripts/tasks/how-to-examples.md
+++ b/scripts/tasks/how-to-examples.md
@@ -1,11 +1,11 @@
 ---
-title: 'Examples'
+title: 'Examples overview'
 description: 'A set of examples for common Electron features'
 slug: examples
 hide_title: false
 ---
 
-# Examples
+# Examples overview
 
 In this section, we have collected a set of guides for common features
 that you may want to implement in your Electron application. Each guide
@@ -34,5 +34,5 @@ You can find the full list of "How to?" in the sidebar. If there is
 something that you would like to do that is not documented, please join
 our [Discord server][] and let us know!
 
-[Discord server]: https://discord.com/invite/electron
+[discord server]: https://discord.com/invite/electron
 [fiddle]: https://www.electronjs.org/fiddle

--- a/scripts/tasks/how-to-examples.md
+++ b/scripts/tasks/how-to-examples.md
@@ -1,18 +1,18 @@
 ---
 title: 'Examples'
-description: 'Electron examples directly for you to use'
+description: 'A set of examples for common Electron features'
 slug: examples
 hide_title: false
 ---
 
 # Examples
 
-In this section we have documented some of the most popular things developers do
-in their Electron applications. The easiest way to run the examples is using
-[Fiddle][fiddle]. To do this, first you will have to download and install the
-right version for your Operating System from [here][fiddle].
+In this section, we have collected a set of guides for common features
+that you may want to implement in your Electron application. Each guide
+contains a practical example in a minimal, self-contained example app.
+The easiest way to run these examples is by downloading [Electron Fiddle][fiddle].
 
-Once you have done this, you can press on the "Open in Fiddle" button that you
+Once Fiddle is installed, you can press on the "Open in Fiddle" button that you
 will find below code samples like the following one:
 
 ```fiddle docs/fiddles/quick-start

--- a/sidebars.js
+++ b/sidebars.js
@@ -61,6 +61,7 @@ module.exports = {
       type: 'category',
       label: 'How To',
       items: [
+        'how-to/examples',
         'how-to/dark-mode',
         'how-to/desktop-environment-integration',
         'how-to/fuses',


### PR DESCRIPTION
Add the top navigation link "Examples" and a new page that explains how
to acquire Fiddle and run the examples available in the sidebar.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Partial work on #2