### PR TITLE
fix: show titles in docs

### DIFF
--- a/create-electron-documentation/package.json
+++ b/create-electron-documentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-electron-documentation",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Generator to easily create new documentation pages for Electron with code examples.",
   "bin": "./index.js",
   "repository": {

--- a/create-electron-documentation/templates/documentation.md
+++ b/create-electron-documentation/templates/documentation.md
@@ -2,7 +2,7 @@
 title: ${title}
 description: ${description}
 slug: ${slug}
-hide_title: true
+hide_title: false
 ---
 
 # ${title}

--- a/scripts/tasks/add-frontmatter.js
+++ b/scripts/tasks/add-frontmatter.js
@@ -123,7 +123,7 @@ const addFrontMatter = (content, filepath) => {
 title: "${title}"
 description: "${description.replace(/"/g, '\\"')}"
 slug: ${path.basename(filepath, '.md')}
-hide_title: true
+hide_title: false
 ---
 
 ${content}`;


### PR DESCRIPTION
With the update to .75 the titles are hidden and `hide_title` has to be
disabled. It was enabled initially because otherwise titles were
duplicated (one from frontmatter, the other from the markdown).