### PR TITLE
feat: allow different files to be focused in an embedded fiddle

### DIFF
--- a/src/transformers/fiddle-embedder.js
+++ b/src/transformers/fiddle-embedder.js
@@ -59,7 +59,7 @@ async function transformer(tree) {
     const options = {};
 
     // If there are optional parameters, parse them out to pass to the getFiddleAST method.
-    if (others.length) {
+    if (others.length > 0) {
       for (const option of others) {
         // Use indexOf to support bizzare combinations like `|key=Myvalue=2` (which will properly 
         // parse to {'key': 'Myvalue=2'})

--- a/src/transformers/fiddle-embedder.js
+++ b/src/transformers/fiddle-embedder.js
@@ -100,7 +100,7 @@ function getFiddleAST(dir, version, { focus = "main.js" }) {
   }
 
   if (!fileNames.includes(focus)) {
-    throw new Error(`Provided focus (${focus}) is not an available file in this fiddle (${dir}). Available files are [${fileNames.join(",")}]`);
+    throw new Error(`Provided focus (${focus}) is not an available file in this fiddle (${dir}). Available files are [${fileNames.join(", ")}]`);
   }
 
   for (const file of fileNames) {


### PR DESCRIPTION
Add support for custom parameterization in the fiddle's code block header.

Example:
````
```javascript fiddle='docs/fiddles/features/keyboard-shortcuts/web-apis|focus=renderer.js'
```
````

This will default the focused tab to `renderer.js`.

![image](https://user-images.githubusercontent.com/556834/118920244-e47a2400-b8ea-11eb-943b-21fc44c38ef2.png)


To minimize focus issues as fiddles are changed, if the provided file is not found a compile-time error will occur.

![image](https://user-images.githubusercontent.com/556834/118920060-7fbec980-b8ea-11eb-8c6e-a22f8fb2dc6e.png)


Fixes: #34
cc: @erickzhao 