### PR TITLE
feat: navigation improvements

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,6 +61,14 @@ module.exports = {
               label: 'Getting Started',
               to: '/',
             },
+            {
+              label: 'Performance',
+              to: '/performance/',
+            },
+            {
+              label: 'Security',
+              to: '/security/',
+            },
           ],
         },
         {

--- a/scripts/tasks/add-frontmatter.js
+++ b/scripts/tasks/add-frontmatter.js
@@ -123,9 +123,18 @@ const addFrontMatter = (content, filepath) => {
     : titleFromPath(filepath).trim();
 
   const description = descriptionFromContent(content);
-  const slug = filepath.endsWith(START_PAGE)
-    ? '/'
-    : path.basename(filepath, '.md');
+  const defaultSlug = path.basename(filepath, '.md');
+
+  let slug;
+
+  if (filepath.endsWith(START_PAGE)) {
+    slug = '/';
+  } else if (path.dirname(filepath).endsWith(defaultSlug)) {
+    // We want paths like `/security/security/` to be `/security/`
+    slug = `/${defaultSlug}/`;
+  } else {
+    slug = defaultSlug;
+  }
 
   const mdWithFrontmatter = `---
 title: "${title}"


### PR DESCRIPTION
If a page has the same name as the folder where it is, it will become
the landing page for that section. E.g.: `/security/security.md` will be
available via `/security` instead of `/security`.

Also add the sections `Performance` and `Security` to the footer
navigation to increase awareness.