### PR TITLE
fix: only trim trailing spaces for API markdown mod

### DIFF
--- a/scripts/tasks/md-fixers.js
+++ b/scripts/tasks/md-fixers.js
@@ -67,7 +67,7 @@ const apiTransformer = (line) => {
     matches[0],
     `${matches[1]}\`${matches[2].trim()}\` ${matches[3]
       .trim()
-      .replace(/>/g, '&#62;')} ${matches[4].trim()}`.trim() // matches[4] could be empty and thus end up with a trailing space
+      .replace(/>/g, '&#62;')} ${matches[4].trim()}`.trimEnd() // matches[4] could be empty and thus end up with a trailing space
   );
 
   return newLine;


### PR DESCRIPTION
Fixes #56

In the `prebuild` script, we have a step that transforms the raw markdown content from our API docs to work with MDX (ref #3).

https://github.com/electron/electronjs.org-new/blob/5a8d040ade644377220775ea2f2ddb484567c7a8/scripts/tasks/md-fixers.js#L39-L74

We trim the final string output in this transformation, which inadvertently resets all leading whitespace and flattens all Markdown lists in the API docs.

This PR uses `trimEnd()` instead of `trim()` to only remove trailing whitespace instead.
