### PR TITLE
fix: never highlight "Examples" in navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,9 +40,9 @@ module.exports = {
         },
         {
           label: 'Examples',
-          type: 'doc',
-          docId: 'how-to/examples',
+          to: 'how-to/examples',
           position: 'left',
+          activeBaseRegex: '^\b$' // never active
         },
         {
           href: 'https://github.com/electron/electron',


### PR DESCRIPTION
Closes #52 