### PR TITLE
feat: link to external Releases homepage in navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,6 +47,11 @@ module.exports = {
         },
         { to: 'blog', label: 'Blog', position: 'left' },
         {
+          href: 'https://releases.electronjs.org',
+          label: 'Releases',
+          position: 'right',
+        },
+        {
           href: 'https://github.com/electron/electron',
           label: 'GitHub',
           position: 'right',

--- a/i18n/en-US/docusaurus-theme-classic/navbar.json
+++ b/i18n/en-US/docusaurus-theme-classic/navbar.json
@@ -19,6 +19,10 @@
     "message": "Blog",
     "description": "Navbar item with label Blog"
   },
+  "item.label.Releases": {
+    "message": "Releases",
+    "description": "Navbar item with label Releases"
+  },
   "item.label.GitHub": {
     "message": "GitHub",
     "description": "Navbar item with label GitHub"


### PR DESCRIPTION
Closes #73 

Adds an external link to https://releases.electronjs.org 