### PR TITLE
fix: remove deprecated doc from sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -65,7 +65,6 @@ module.exports = {
       items: [
         'latest/tutorial/examples',
         'latest/tutorial/dark-mode',
-        'latest/tutorial/desktop-environment-integration',
         'latest/tutorial/fuses',
         'latest/tutorial/in-app-purchases',
         'latest/tutorial/keyboard-shortcuts',


### PR DESCRIPTION
The `Desktop Environment Integration` was removed upstream, which broke builds late last week.