### PR TITLE
fix: use @2x avatar photo for blog post authors

### DIFF
--- a/blog/12-week-cadence.md
+++ b/blog/12-week-cadence.md
@@ -4,7 +4,7 @@ date: 2019-05-13T00:00:00.000Z
 authors:
   name: sofianguy
   url: 'https://github.com/sofianguy'
-  image_url: 'https://github.com/sofianguy.png?size=48'
+  image_url: 'https://github.com/sofianguy.png?size=96'
 slug: 12-week-cadence
 ---
 🎉 Electron is moving to release a new major stable version every 12 weeks! 🎉

--- a/blog/2015-whats-new-in-electron.md
+++ b/blog/2015-whats-new-in-electron.md
@@ -4,7 +4,7 @@ date: 2015-10-15T00:00:00.000Z
 authors:
   name: jlord
   url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=48'
+  image_url: 'https://github.com/jlord.png?size=96'
 slug: 2015-whats-new-in-electron
 ---
 There have been some interesting updates and talks given on Electron recently, here's a roundup.

--- a/blog/2020-season-of-docs.md
+++ b/blog/2020-season-of-docs.md
@@ -4,7 +4,7 @@ date: 2020-05-21T00:00:00.000Z
 authors:
   - name: erickzhao
     url: 'https://github.com/erickzhao'
-    image_url: 'https://github.com/erickzhao.png?size=48'
+    image_url: 'https://github.com/erickzhao.png?size=96'
 slug: 2020-season-of-docs
 ---
 Electron is proud to be participating in the second edition of Google's Season of Docs initiative, which pairs mentors from open source organizations with technical writers to improve project documentation.

--- a/blog/8-week-cadence.md
+++ b/blog/8-week-cadence.md
@@ -4,7 +4,7 @@ date: 2021-07-14T00:00:00.000Z
 authors:
   name: VerteDinde
   url: 'https://github.com/VerteDinde'
-  image_url: 'https://github.com/VerteDinde.png?size=48'
+  image_url: 'https://github.com/VerteDinde.png?size=96'
 slug: 8-week-cadence
 ---
 Beginning in September 2021, Electron will release a new major stable version every 8 weeks.

--- a/blog/accessibility-tools.md
+++ b/blog/accessibility-tools.md
@@ -4,7 +4,7 @@ date: 2016-08-23T00:00:00.000Z
 authors:
   name: jlord
   url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=48'
+  image_url: 'https://github.com/jlord.png?size=96'
 slug: accessibility-tools
 ---
 Making accessible applications is important and we're happy to introduce new functionality to [Devtron](https://electronjs.org/devtron) and [Spectron](https://electronjs.org/spectron) that gives developers the opportunity to make their apps better for everyone.

--- a/blog/api-docs-json-schema.md
+++ b/blog/api-docs-json-schema.md
@@ -4,7 +4,7 @@ date: 2016-09-27T00:00:00.000Z
 authors:
   name: zeke
   url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=48'
+  image_url: 'https://github.com/zeke.png?size=96'
 slug: api-docs-json-schema
 ---
 Today we're announcing some improvements to Electron's documentation. Every new

--- a/blog/app-feedback-program.md
+++ b/blog/app-feedback-program.md
@@ -4,7 +4,7 @@ date: 2018-10-02T00:00:00.000Z
 authors:
   name: sofianguy
   url: 'https://github.com/sofianguy'
-  image_url: 'https://github.com/sofianguy.png?size=48'
+  image_url: 'https://github.com/sofianguy.png?size=96'
 slug: app-feedback-program
 ---
 Electron is working on making its release cycles faster and more stable. To make that possible, we've started the App Feedback Program for large-scale Electron apps to test our beta releases and report app-specific issues to us. This helps us to prioritize work that will get applications upgraded to our next stable release sooner.

--- a/blog/apple-silicon.md
+++ b/blog/apple-silicon.md
@@ -4,7 +4,7 @@ date: 2020-10-15T00:00:00.000Z
 authors:
   name: MarshallOfSound
   url: 'https://github.com/MarshallOfSound'
-  image_url: 'https://github.com/MarshallOfSound.png?size=48'
+  image_url: 'https://github.com/MarshallOfSound.png?size=96'
 slug: apple-silicon
 ---
 With Apple Silicon hardware being released later this year, what does the path look like for you to get your Electron app running on the new hardware?

--- a/blog/august-2016-roundup.md
+++ b/blog/august-2016-roundup.md
@@ -4,7 +4,7 @@ date: 2016-09-06T00:00:00.000Z
 authors:
   name: jlord
   url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=48'
+  image_url: 'https://github.com/jlord.png?size=96'
 slug: august-2016-roundup
 ---
 Here are the new Electron apps that were added to the site in August.

--- a/blog/autoupdating-electron-apps.md
+++ b/blog/autoupdating-electron-apps.md
@@ -4,7 +4,7 @@ date: 2018-05-01T00:00:00.000Z
 authors:
   name: zeke
   url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=48'
+  image_url: 'https://github.com/zeke.png?size=96'
 slug: autoupdating-electron-apps
 ---
 Today we're releasing a free, open-source, hosted

--- a/blog/beaker-browser.md
+++ b/blog/beaker-browser.md
@@ -4,10 +4,10 @@ date: 2017-02-07T00:00:00.000Z
 authors:
   - name: pfrazee
     url: 'https://github.com/pfrazee'
-    image_url: 'https://github.com/pfrazee.png?size=48'
+    image_url: 'https://github.com/pfrazee.png?size=96'
   - name: zeke
     url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=48'
+    image_url: 'https://github.com/zeke.png?size=96'
 slug: beaker-browser
 ---
 This week we caught up with [Paul Frazee](http://pfrazee.github.io/), creator

--- a/blog/cadence-pause.md
+++ b/blog/cadence-pause.md
@@ -4,7 +4,7 @@ date: 2020-03-19T00:00:00.000Z
 authors:
   name: codebytere
   url: 'https://github.com/codebytere'
-  image_url: 'https://github.com/codebytere.png?size=48'
+  image_url: 'https://github.com/codebytere.png?size=96'
 slug: cadence-pause
 ---
 Electron is temporarily pausing major releases

--- a/blog/certificate-transparency-fix.md
+++ b/blog/certificate-transparency-fix.md
@@ -4,7 +4,7 @@ date: 2016-12-09T00:00:00.000Z
 authors:
   name: kevinsawicki
   url: 'https://github.com/kevinsawicki'
-  image_url: 'https://github.com/kevinsawicki.png?size=48'
+  image_url: 'https://github.com/kevinsawicki.png?size=96'
 slug: certificate-transparency-fix
 ---
 Electron [1.4.12] contains an important patch that fixes an upstream Chrome

--- a/blog/chromium-rce-vulnerability.md
+++ b/blog/chromium-rce-vulnerability.md
@@ -4,7 +4,7 @@ date: 2017-09-27T00:00:00.000Z
 authors:
   name: zeke
   url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=48'
+  image_url: 'https://github.com/zeke.png?size=96'
 slug: chromium-rce-vulnerability
 ---
 A remote code execution vulnerability has been discovered in Google Chromium

--- a/blog/cve-2019-13720.md
+++ b/blog/cve-2019-13720.md
@@ -4,7 +4,7 @@ date: 2019-11-04T00:00:00.000Z
 authors:
   name: nornagon
   url: 'https://github.com/nornagon'
-  image_url: 'https://github.com/nornagon.png?size=48'
+  image_url: 'https://github.com/nornagon.png?size=96'
 slug: cve-2019-13720
 ---
 A High severity vulnerability has been discovered in Chrome which affects all software based on Chromium, including Electron.

--- a/blog/dat.md
+++ b/blog/dat.md
@@ -4,16 +4,16 @@ date: 2017-02-21T00:00:00.000Z
 authors:
   - name: karissa
     url: 'https://github.com/karissa'
-    image_url: 'https://github.com/karissa.png?size=48'
+    image_url: 'https://github.com/karissa.png?size=96'
   - name: yoshuawuyts
     url: 'https://github.com/yoshuawuyts'
-    image_url: 'https://github.com/yoshuawuyts.png?size=48'
+    image_url: 'https://github.com/yoshuawuyts.png?size=96'
   - name: maxogden
     url: 'https://github.com/maxogden'
-    image_url: 'https://github.com/maxogden.png?size=48'
+    image_url: 'https://github.com/maxogden.png?size=96'
   - name: zeke
     url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=48'
+    image_url: 'https://github.com/zeke.png?size=96'
 slug: dat
 ---
 This week's featured project is [Dat](https://datproject.org/), a

--- a/blog/discord-hacktoberfest-2020.md
+++ b/blog/discord-hacktoberfest-2020.md
@@ -4,7 +4,7 @@ date: 2020-10-01T00:00:00.000Z
 authors:
   - name: erickzhao
     url: 'https://github.com/erickzhao'
-    image_url: 'https://github.com/erickzhao.png?size=48'
+    image_url: 'https://github.com/erickzhao.png?size=96'
 slug: discord-hacktoberfest-2020
 ---
 Join us for community bonding and a month-long celebration of open-source.

--- a/blog/electron-1-0.md
+++ b/blog/electron-1-0.md
@@ -4,7 +4,7 @@ date: 2016-05-11T00:00:00.000Z
 authors:
   name: jlord
   url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=48'
+  image_url: 'https://github.com/jlord.png?size=96'
 slug: electron-1-0
 ---
 For the last two years, Electron has helped developers build cross platform

--- a/blog/electron-10-0.md
+++ b/blog/electron-10-0.md
@@ -4,10 +4,10 @@ date: 2020-08-25T00:00:00.000Z
 authors:
   - name: VerteDinde
     url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=48'
+    image_url: 'https://github.com/VerteDinde.png?size=96'
   - name: sofianguy
     url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=48'
+    image_url: 'https://github.com/sofianguy.png?size=96'
 slug: electron-10-0
 ---
 Electron 10.0.0 has been released! It includes upgrades to Chromium `85`, V8 `8.5`, and Node.js `12.16`. We've added several new API integrations and improvements. Read below for more details!

--- a/blog/electron-11-0.md
+++ b/blog/electron-11-0.md
@@ -4,7 +4,7 @@ date: 2020-11-17T00:00:00.000Z
 authors:
   - name: VerteDinde
     url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=48'
+    image_url: 'https://github.com/VerteDinde.png?size=96'
 slug: electron-11-0
 ---
 Electron 11.0.0 has been released! It includes upgrades to Chromium `87`, V8 `8.7`, and Node.js `12.18.3`. We've added support for Apple silicon, and general improvements. Read below for more details!

--- a/blog/electron-12-0.md
+++ b/blog/electron-12-0.md
@@ -4,13 +4,13 @@ date: 2021-03-02T00:00:00.000Z
 authors:
   - name: VerteDinde
     url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=48'
+    image_url: 'https://github.com/VerteDinde.png?size=96'
   - name: mlaurencin
     url: 'https://github.com/mlaurencin'
-    image_url: 'https://github.com/mlaurencin.png?size=48'
+    image_url: 'https://github.com/mlaurencin.png?size=96'
   - name: sofianguy
     url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=48'
+    image_url: 'https://github.com/sofianguy.png?size=96'
 slug: electron-12-0
 ---
 Electron 12.0.0 has been released! It includes upgrades to Chromium `89`, V8 `8.9` and Node.js `14.16`. We've added changes to the remote module, new defaults for contextIsolation, a new webFrameMain API, and general improvements. Read below for more details!

--- a/blog/electron-13-0.md
+++ b/blog/electron-13-0.md
@@ -4,13 +4,13 @@ date: 2021-05-25T00:00:00.000Z
 authors:
   - name: sofianguy
     url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=48'
+    image_url: 'https://github.com/sofianguy.png?size=96'
   - name: georgexu99
     url: 'https://github.com/georgexu99'
-    image_url: 'https://github.com/georgexu99.png?size=48'
+    image_url: 'https://github.com/georgexu99.png?size=96'
   - name: VerteDinde
     url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=48'
+    image_url: 'https://github.com/VerteDinde.png?size=96'
 slug: electron-13-0
 ---
 Electron 13.0.0 has been released! It includes upgrades to Chromium `91` and V8 `9.1`. We've added several API updates, bug fixes, and general improvements. Read below for more details!

--- a/blog/electron-14-0.md
+++ b/blog/electron-14-0.md
@@ -4,13 +4,13 @@ date: 2021-08-31T00:00:00.000Z
 authors:
   - name: sofianguy
     url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=48'
+    image_url: 'https://github.com/sofianguy.png?size=96'
   - name: clavin
     url: 'https://github.com/clavin'
-    image_url: 'https://github.com/clavin.png?size=48'
+    image_url: 'https://github.com/clavin.png?size=96'
   - name: ckerr
     url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=48'
+    image_url: 'https://github.com/ckerr.png?size=96'
 slug: electron-14-0
 ---
 

--- a/blog/electron-2-0.md
+++ b/blog/electron-2-0.md
@@ -4,7 +4,7 @@ date: 2018-05-02T00:00:00.000Z
 authors:
   name: ckerr
   url: 'https://github.com/ckerr'
-  image_url: 'https://github.com/ckerr.png?size=48'
+  image_url: 'https://github.com/ckerr.png?size=96'
 slug: electron-2-0
 ---
 After more than four months of development, eight beta releases, and worldwide

--- a/blog/electron-2-semantic-boogaloo.md
+++ b/blog/electron-2-semantic-boogaloo.md
@@ -4,7 +4,7 @@ date: 2017-12-06T00:00:00.000Z
 authors:
   name: groundwater
   url: 'https://github.com/groundwater'
-  image_url: 'https://github.com/groundwater.png?size=48'
+  image_url: 'https://github.com/groundwater.png?size=96'
 slug: electron-2-semantic-boogaloo
 ---
 A new major version of Electron is in the works, and with it some changes to our versioning strategy. As of version 2.0.0, Electron will strictly adhere to Semantic Versioning.

--- a/blog/electron-3-0.md
+++ b/blog/electron-3-0.md
@@ -4,7 +4,7 @@ date: 2018-09-18T00:00:00.000Z
 authors:
   name: codebytere
   url: 'https://github.com/codebytere'
-  image_url: 'https://github.com/codebytere.png?size=48'
+  image_url: 'https://github.com/codebytere.png?size=96'
 slug: electron-3-0
 ---
 The Electron team is excited to announce that the first stable release of Electron 3 is now

--- a/blog/electron-37.md
+++ b/blog/electron-37.md
@@ -4,7 +4,7 @@ date: 2016-03-25T00:00:00.000Z
 authors:
   name: zeke
   url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=48'
+  image_url: 'https://github.com/zeke.png?size=96'
 slug: electron-37
 ---
 Electron `0.37` was recently [released](https://github.com/electron/electron/releases) and included a major upgrade from Chrome 47 to Chrome 49 and also several new core APIs. This latest release brings in all the new features shipped in [Chrome 48](http://blog.chromium.org/2015/12/chrome-48-beta-present-to-cast-devices_91.html) and [Chrome 49](http://blog.chromium.org/2016/02/chrome-49-beta-css-custom-properties.html). This includes CSS custom properties, increased [ES6](http://www.ecma-international.org/ecma-262/6.0/) support, `KeyboardEvent` improvements, `Promise` improvements, and many other new features now available in your Electron app.

--- a/blog/electron-4-0.md
+++ b/blog/electron-4-0.md
@@ -4,7 +4,7 @@ date: 2018-12-20T00:00:00.000Z
 authors:
   name: BinaryMuse
   url: 'https://github.com/BinaryMuse'
-  image_url: 'https://github.com/BinaryMuse.png?size=48'
+  image_url: 'https://github.com/BinaryMuse.png?size=96'
 slug: electron-4-0
 ---
 The Electron team is excited to announce that the stable release of Electron 4 is now available! You can install it from [electronjs.org](https://electronjs.org/) or from npm via `npm install electron@latest`. The release is packed with upgrades, fixes, and new features, and we can't wait to see what you build with them. Read more for details about this release, and please share any feedback you have as you explore!

--- a/blog/electron-5-0-timeline.md
+++ b/blog/electron-5-0-timeline.md
@@ -4,7 +4,7 @@ date: 2019-01-25T00:00:00.000Z
 authors:
   name: sofianguy
   url: 'https://github.com/sofianguy'
-  image_url: 'https://github.com/sofianguy.png?size=48'
+  image_url: 'https://github.com/sofianguy.png?size=96'
 slug: electron-5-0-timeline
 ---
 For the first time ever, Electron is excited to publicize our release schedule starting with v5.0.0. This is our first step in having a public, long-term timeline.

--- a/blog/electron-5-0.md
+++ b/blog/electron-5-0.md
@@ -4,13 +4,13 @@ date: 2019-04-23T00:00:00.000Z
 authors:
   - name: BinaryMuse
     url: 'https://github.com/BinaryMuse'
-    image_url: 'https://github.com/BinaryMuse.png?size=48'
+    image_url: 'https://github.com/BinaryMuse.png?size=96'
   - name: ckerr
     url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=48'
+    image_url: 'https://github.com/ckerr.png?size=96'
   - name: jkleinsc
     url: 'https://github.com/jkleinsc'
-    image_url: 'https://github.com/jkleinsc.png?size=48'
+    image_url: 'https://github.com/jkleinsc.png?size=96'
 slug: electron-5-0
 ---
 The Electron team is excited to announce the release of Electron 5.0.0! You can install it with npm via `npm install electron@latest` or download the tarballs from [our releases page](https://github.com/electron/electron/releases/tag/v5.0.0). The release is packed with upgrades, fixes, and new features. We can't wait to see what you build with them! Continue reading for details about this release, and please share any feedback you have!

--- a/blog/electron-6-0.md
+++ b/blog/electron-6-0.md
@@ -4,13 +4,13 @@ date: 2019-07-30T00:00:00.000Z
 authors:
   - name: sofianguy
     url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=48'
+    image_url: 'https://github.com/sofianguy.png?size=96'
   - name: ckerr
     url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=48'
+    image_url: 'https://github.com/ckerr.png?size=96'
   - name: codebytere
     url: 'https://github.com/codebytere'
-    image_url: 'https://github.com/codebytere.png?size=48'
+    image_url: 'https://github.com/codebytere.png?size=96'
 slug: electron-6-0
 ---
 The Electron team is excited to announce the release of Electron 6.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://electronjs.org/releases/stable). The release is packed with upgrades, fixes, and new features. We can't wait to see what you build with them! Continue reading for details about this release, and please share any feedback you have!

--- a/blog/electron-7-0.md
+++ b/blog/electron-7-0.md
@@ -4,10 +4,10 @@ date: 2019-10-22T00:00:00.000Z
 authors:
   - name: sofianguy
     url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=48'
+    image_url: 'https://github.com/sofianguy.png?size=96'
   - name: ckerr
     url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=48'
+    image_url: 'https://github.com/ckerr.png?size=96'
 slug: electron-7-0
 ---
 Electron 7.0.0 has been released! It includes upgrades to Chromium 78, V8 7.8, and Node.js 12.8.1. We've added a Window on Arm 64 release, faster IPC methods, a new `nativeTheme` API, and much more!

--- a/blog/electron-8-0.md
+++ b/blog/electron-8-0.md
@@ -4,10 +4,10 @@ date: 2020-02-04T00:00:00.000Z
 authors:
   - name: jkleinsc
     url: 'https://github.com/jkleinsc'
-    image_url: 'https://github.com/jkleinsc.png?size=48'
+    image_url: 'https://github.com/jkleinsc.png?size=96'
   - name: sofianguy
     url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=48'
+    image_url: 'https://github.com/sofianguy.png?size=96'
 slug: electron-8-0
 ---
 Electron 8.0.0 has been released! It includes upgrades to Chromium `80`, V8 `8.0`, and Node.js `12.13.0`. We've added Chrome's built-in spellchecker, and much more!

--- a/blog/electron-9-0.md
+++ b/blog/electron-9-0.md
@@ -4,10 +4,10 @@ date: 2020-05-19T00:00:00.000Z
 authors:
   - name: sofianguy
     url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=48'
+    image_url: 'https://github.com/sofianguy.png?size=96'
   - name: VerteDinde
     url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=48'
+    image_url: 'https://github.com/VerteDinde.png?size=96'
 slug: electron-9-0
 ---
 Electron 9.0.0 has been released! It includes upgrades to Chromium `83`, V8 `8.3`, and Node.js `12.14`. We've added several new API integrations for our spellchecker feature, enabled PDF viewer, and much more!

--- a/blog/electron-api-changes.md
+++ b/blog/electron-api-changes.md
@@ -4,7 +4,7 @@ date: 2015-11-17T00:00:00.000Z
 authors:
   name: zcbenz
   url: 'https://github.com/zcbenz'
-  image_url: 'https://github.com/zcbenz.png?size=48'
+  image_url: 'https://github.com/zcbenz.png?size=96'
 slug: electron-api-changes
 ---
 Since the beginning of Electron, starting way back when it used to be called Atom-Shell, we have been experimenting with providing a nice cross-platform JavaScript API for Chromium's content module and native GUI components. The APIs started very organically, and over time we have made several changes to improve the initial designs.

--- a/blog/electron-doumentation.md
+++ b/blog/electron-doumentation.md
@@ -4,7 +4,7 @@ date: 2015-06-04T00:00:00.000Z
 authors:
   name: jlord
   url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=48'
+  image_url: 'https://github.com/jlord.png?size=96'
 slug: electron-doumentation
 ---
 This week we've given Electron's documentation a home on [electronjs.org](https://electronjs.org). You can visit [/docs/latest](https://electronjs.org/docs/latest) for the latest set of docs. We'll keep versions of older docs, too, so you're able to visit [/docs/vX.XX.X](https://electronjs.org/docs/v0.26.0) for the docs that correlate to the version you're using.

--- a/blog/electron-internals-building-chromium-as-a-library.md
+++ b/blog/electron-internals-building-chromium-as-a-library.md
@@ -4,7 +4,7 @@ date: 2017-03-03T00:00:00.000Z
 authors:
   name: zcbenz
   url: 'https://github.com/zcbenz'
-  image_url: 'https://github.com/zcbenz.png?size=48'
+  image_url: 'https://github.com/zcbenz.png?size=96'
 slug: electron-internals-building-chromium-as-a-library
 ---
 Electron is based on Google's open-source Chromium, a project that is not

--- a/blog/electron-internals-node-integration.md
+++ b/blog/electron-internals-node-integration.md
@@ -4,7 +4,7 @@ date: 2016-07-28T00:00:00.000Z
 authors:
   name: zcbenz
   url: 'https://github.com/zcbenz'
-  image_url: 'https://github.com/zcbenz.png?size=48'
+  image_url: 'https://github.com/zcbenz.png?size=96'
 slug: electron-internals-node-integration
 ---
 This is the first post of a series that explains the internals of Electron. This

--- a/blog/electron-internals-using-node-as-a-library.md
+++ b/blog/electron-internals-using-node-as-a-library.md
@@ -4,7 +4,7 @@ date: 2016-08-08T00:00:00.000Z
 authors:
   name: zcbenz
   url: 'https://github.com/zcbenz'
-  image_url: 'https://github.com/zcbenz.png?size=48'
+  image_url: 'https://github.com/zcbenz.png?size=96'
 slug: electron-internals-using-node-as-a-library
 ---
 This is the second post in an ongoing series explaining the internals of

--- a/blog/electron-internals-weak-references.md
+++ b/blog/electron-internals-weak-references.md
@@ -4,7 +4,7 @@ date: 2016-09-20T00:00:00.000Z
 authors:
   name: zcbenz
   url: 'https://github.com/zcbenz'
-  image_url: 'https://github.com/zcbenz.png?size=48'
+  image_url: 'https://github.com/zcbenz.png?size=96'
 slug: electron-internals-weak-references
 ---
 As a language with garbage collection, JavaScript frees users from managing

--- a/blog/electron-joins-openjsf.md
+++ b/blog/electron-joins-openjsf.md
@@ -4,7 +4,7 @@ date: 2019-12-11T00:00:00.000Z
 authors:
   - name: felixrieseberg
     url: 'https://github.com/felixrieseberg'
-    image_url: 'https://github.com/felixrieseberg.png?size=48'
+    image_url: 'https://github.com/felixrieseberg.png?size=96'
 slug: electron-joins-openjsf
 ---
 At [Node+JS Interactive](https://events19.linuxfoundation.org/events/nodejs-interactive-2019/) in Montreal, the [OpenJS Foundation](https://openjsf.org/) announced that it accepted Electron into the Foundation's incubation program. The Foundation is committed to supporting the healthy growth of the JavaScript ecosystem and web technologies by providing a neutral organization to host and sustain projects, as well as collaboratively fund activities for the benefit of the community at large.

--- a/blog/electron-meetup.md
+++ b/blog/electron-meetup.md
@@ -4,7 +4,7 @@ date: 2015-09-17T00:00:00.000Z
 authors:
   name: jlord
   url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=48'
+  image_url: 'https://github.com/jlord.png?size=96'
 slug: electron-meetup
 ---
 Join us September 29th at GitHub's HQ for an Electron meetup hosted by Atom team members [@jlord](https://github.com/jlord) and [@kevinsawicki](https://github.com/kevinsawicki). There will be talks, food to snack on, and time to hangout and meet others doing cool things with Electron. We'll also have a bit of time to do lightning talks for those interested. Hope to see you there!

--- a/blog/electron-openjs-impact-project.md
+++ b/blog/electron-openjs-impact-project.md
@@ -4,7 +4,7 @@ date: 2020-06-23T00:00:00.000Z
 authors:
   - name: VerteDinde
     url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=48'
+    image_url: 'https://github.com/VerteDinde.png?size=96'
 slug: electron-openjs-impact-project
 ---
 At [OpenJS World](https://events.linuxfoundation.org/openjs-world/) this morning, we announced that Electron has officially graduated from the [OpenJS Foundation's](https://openjsf.org/) incubation program, and is now an OpenJS Foundation Impact Project. 

--- a/blog/electron-podcasts.md
+++ b/blog/electron-podcasts.md
@@ -4,7 +4,7 @@ date: 2016-07-26T00:00:00.000Z
 authors:
   name: jlord
   url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=48'
+  image_url: 'https://github.com/jlord.png?size=96'
 slug: electron-podcasts
 ---
 Looking for an introduction to Electron? Two new podcasts have just been released that give a great overview of what it is, why it was built, and how it is being used.

--- a/blog/electron-updates-mac-app-store-and-windows-auto-updater.md
+++ b/blog/electron-updates-mac-app-store-and-windows-auto-updater.md
@@ -4,7 +4,7 @@ date: 2015-11-05T00:00:00.000Z
 authors:
   name: jlord
   url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=48'
+  image_url: 'https://github.com/jlord.png?size=96'
 slug: electron-updates-mac-app-store-and-windows-auto-updater
 ---
 Recently Electron added two exciting features: a Mac App Store compatible build and a built-in Windows auto updater.

--- a/blog/electron.md
+++ b/blog/electron.md
@@ -4,7 +4,7 @@ date: 2015-04-23T00:00:00.000Z
 authors:
   name: kevinsawicki
   url: 'https://github.com/kevinsawicki'
-  image_url: 'https://github.com/kevinsawicki.png?size=48'
+  image_url: 'https://github.com/kevinsawicki.png?size=96'
 slug: electron
 ---
 Atom Shell is now called Electron. You can learn more about Electron and what people are building with it at its new home [electronjs.org][electron].

--- a/blog/filereader-fix.md
+++ b/blog/filereader-fix.md
@@ -4,7 +4,7 @@ date: 2019-03-07T00:00:00.000Z
 authors:
   name: marshallofsound
   url: 'https://github.com/marshallofsound'
-  image_url: 'https://github.com/marshallofsound.png?size=48'
+  image_url: 'https://github.com/marshallofsound.png?size=96'
 slug: filereader-fix
 ---
 A High severity vulnerability has been discovered in Chrome which affects all software based on Chromium, including Electron.

--- a/blog/from-native-to-js.md
+++ b/blog/from-native-to-js.md
@@ -4,7 +4,7 @@ date: 2019-03-19T00:00:00.000Z
 authors:
   name: codebytere
   url: 'https://github.com/codebytere'
-  image_url: 'https://github.com/codebytere.png?size=48'
+  image_url: 'https://github.com/codebytere.png?size=96'
 slug: from-native-to-js
 ---
 How do Electron's features written in C++ or Objective-C get to JavaScript so they're available to an end-user?

--- a/blog/ghost.md
+++ b/blog/ghost.md
@@ -4,10 +4,10 @@ date: 2017-02-14T00:00:00.000Z
 authors:
   - name: felixrieseberg
     url: 'https://github.com/felixrieseberg'
-    image_url: 'https://github.com/felixrieseberg.png?size=48'
+    image_url: 'https://github.com/felixrieseberg.png?size=96'
   - name: zeke
     url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=48'
+    image_url: 'https://github.com/zeke.png?size=96'
 slug: ghost
 ---
 This week we chatted with [Felix Rieseberg](https://felixrieseberg.com/), desktop engineer at [Slack](https://slack.com/) and maintainer of [Ghost Desktop](https://ghost.org/downloads/), an Electron client for the [Ghost](https://ghost.org/) publishing platform.

--- a/blog/gn.md
+++ b/blog/gn.md
@@ -4,7 +4,7 @@ date: 2018-09-05T00:00:00.000Z
 authors:
   name: nornagon
   url: 'https://github.com/nornagon'
-  image_url: 'https://github.com/nornagon.png?size=48'
+  image_url: 'https://github.com/nornagon.png?size=96'
 slug: gn
 ---
 Electron now uses GN to build itself. Here's a discussion of why.

--- a/blog/governance.md
+++ b/blog/governance.md
@@ -4,10 +4,10 @@ date: 2019-03-18T00:00:00.000Z
 authors:
   - name: ckerr
     url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=48'
+    image_url: 'https://github.com/ckerr.png?size=96'
   - name: sofianguy
     url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=48'
+    image_url: 'https://github.com/sofianguy.png?size=96'
 slug: governance
 ---
 As Electron grows in popularity for desktop applications, the team working on it has also grown: we have more fulltime maintainers who work for different companies, live in different timezones, and have different interests. We're introducing a governance structure so we can keep growing smoothly.

--- a/blog/i18n-updates.md
+++ b/blog/i18n-updates.md
@@ -4,7 +4,7 @@ date: 2018-06-20T00:00:00.000Z
 authors:
   name: vanessayuenn
   url: 'https://github.com/vanessayuenn'
-  image_url: 'https://github.com/vanessayuenn.png?size=48'
+  image_url: 'https://github.com/vanessayuenn.png?size=96'
 slug: i18n-updates
 ---
 Ever since the [launch](https://electronjs.org/blog/new-website) of the new internationalized Electron website, we have been working hard to make the Electron development experience even more accessible to developers outside of the English speaking world.

--- a/blog/in-app-purchases.md
+++ b/blog/in-app-purchases.md
@@ -4,7 +4,7 @@ date: 2018-04-04T00:00:00.000Z
 authors:
   name: zeke
   url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=48'
+  image_url: 'https://github.com/zeke.png?size=96'
 slug: in-app-purchases
 ---
 The new Electron 2.0 release line is [packed](https://github.com/electron/electron/releases/tag/v2.0.0-beta.1) with new features and fixes. One of the highlights from this new major version is a new

--- a/blog/jasper.md
+++ b/blog/jasper.md
@@ -4,13 +4,13 @@ date: 2017-03-21T00:00:00.000Z
 authors:
   - name: h13i32maru
     url: 'https://github.com/h13i32maru'
-    image_url: 'https://github.com/h13i32maru.png?size=48'
+    image_url: 'https://github.com/h13i32maru.png?size=96'
   - name: watilde
     url: 'https://github.com/watilde'
-    image_url: 'https://github.com/watilde.png?size=48'
+    image_url: 'https://github.com/watilde.png?size=96'
   - name: zeke
     url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=48'
+    image_url: 'https://github.com/zeke.png?size=96'
 slug: jasper
 ---
 This week we interviewed the creator of [Jasper], an Electron-based tool for

--- a/blog/july-2016-roundup.md
+++ b/blog/july-2016-roundup.md
@@ -4,7 +4,7 @@ date: 2016-08-04T00:00:00.000Z
 authors:
   name: jlord
   url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=48'
+  image_url: 'https://github.com/jlord.png?size=96'
 slug: july-2016-roundup
 ---
 We're starting a monthly roundup to highlight activity in the Electron community. Each roundup will feature things like new apps, upcoming meetups, tools, videos, etc.

--- a/blog/kap.md
+++ b/blog/kap.md
@@ -4,13 +4,13 @@ date: 2017-01-31T00:00:00.000Z
 authors:
   - name: skllcrn
     url: 'https://github.com/skllcrn'
-    image_url: 'https://github.com/skllcrn.png?size=48'
+    image_url: 'https://github.com/skllcrn.png?size=96'
   - name: sindresorhus
     url: 'https://github.com/sindresorhus'
-    image_url: 'https://github.com/sindresorhus.png?size=48'
+    image_url: 'https://github.com/sindresorhus.png?size=96'
   - name: zeke
     url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=48'
+    image_url: 'https://github.com/zeke.png?size=96'
 slug: kap
 ---
 The Electron community is growing quickly, and people are creating powerful

--- a/blog/latest-v8-chromium-features.md
+++ b/blog/latest-v8-chromium-features.md
@@ -4,7 +4,7 @@ date: 2016-01-07T00:00:00.000Z
 authors:
   name: jlord
   url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=48'
+  image_url: 'https://github.com/jlord.png?size=96'
 slug: latest-v8-chromium-features
 ---
 Building an Electron application means you only need to create one codebase and design for one browser, which is pretty handy. But because Electron stays up to date with [Node.js](http://nodejs.org) and [Chromium](https://www.chromium.org) as they release, you also get to make use of the great features they ship with. In some cases this eliminates dependencies you might have previously needed to include in a web app.

--- a/blog/linux-32bit-support.md
+++ b/blog/linux-32bit-support.md
@@ -4,7 +4,7 @@ date: 2019-03-04T00:00:00.000Z
 authors:
   name: felixrieseberg
   url: 'https://github.com/felixrieseberg'
-  image_url: 'https://github.com/felixrieseberg.png?size=48'
+  image_url: 'https://github.com/felixrieseberg.png?size=96'
 slug: linux-32bit-support
 ---
 The Electron team will discontinue support for 32-bit Linux (ia32 / i386) starting with Electron v4.0. The last version of Electron that supports 32-bit based installations of Linux is Electron v3.1, which will receive support releases until Electron v6 is released. Support for 64-bit based Linux and `armv7l` will continue unchanged.

--- a/blog/magellan-fix.md
+++ b/blog/magellan-fix.md
@@ -4,7 +4,7 @@ date: 2018-12-18T00:00:00.000Z
 authors:
   name: ckerr
   url: 'https://github.com/ckerr'
-  image_url: 'https://github.com/ckerr.png?size=48'
+  image_url: 'https://github.com/ckerr.png?size=96'
 slug: magellan-fix
 ---
 A remote code execution vulnerability, "[Magellan](https://blade.tencent.com/magellan/index_en.html)," has been discovered affecting software based on SQLite or Chromium, including all versions of Electron.

--- a/blog/new-website.md
+++ b/blog/new-website.md
@@ -4,7 +4,7 @@ date: 2017-11-13T00:00:00.000Z
 authors:
   name: zeke
   url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=48'
+  image_url: 'https://github.com/zeke.png?size=96'
 slug: new-website
 ---
 Electron has a new website at [electronjs.org]! We've replaced

--- a/blog/nodejs-native-addons-and-electron-5.md
+++ b/blog/nodejs-native-addons-and-electron-5.md
@@ -4,7 +4,7 @@ date: 2019-02-01T00:00:00.000Z
 authors:
   name: BinaryMuse
   url: 'https://github.com/BinaryMuse'
-  image_url: 'https://github.com/BinaryMuse.png?size=48'
+  image_url: 'https://github.com/BinaryMuse.png?size=96'
 slug: nodejs-native-addons-and-electron-5
 ---
 If you're having trouble using a native Node.js addon with Electron 5.0, there's a chance it needs to be updated to work with the most recent version of V8.

--- a/blog/npm-install-electron.md
+++ b/blog/npm-install-electron.md
@@ -4,7 +4,7 @@ date: 2016-08-16T00:00:00.000Z
 authors:
   name: zeke
   url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=48'
+  image_url: 'https://github.com/zeke.png?size=96'
 slug: npm-install-electron
 ---
 As of Electron version 1.3.1, you can `npm install electron --save-dev` to

--- a/blog/protocol-handler-fix.md
+++ b/blog/protocol-handler-fix.md
@@ -4,7 +4,7 @@ date: 2018-01-22T00:00:00.000Z
 authors:
   name: zeke
   url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=48'
+  image_url: 'https://github.com/zeke.png?size=96'
 slug: protocol-handler-fix
 ---
 A remote code execution vulnerability has been discovered affecting

--- a/blog/search.md
+++ b/blog/search.md
@@ -4,13 +4,13 @@ date: 2018-06-21T00:00:00.000Z
 authors:
   - name: echjordan
     url: 'https://github.com/echjordan'
-    image_url: 'https://github.com/echjordan.png?size=48'
+    image_url: 'https://github.com/echjordan.png?size=96'
   - name: vanessayuenn
     url: 'https://github.com/vanessayuenn'
-    image_url: 'https://github.com/vanessayuenn.png?size=48'
+    image_url: 'https://github.com/vanessayuenn.png?size=96'
   - name: zeke
     url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=48'
+    image_url: 'https://github.com/zeke.png?size=96'
 slug: search
 ---
 The Electron website has a new search engine that delivers instant results for

--- a/blog/september-2016-roundup.md
+++ b/blog/september-2016-roundup.md
@@ -4,7 +4,7 @@ date: 2016-10-06T00:00:00.000Z
 authors:
   name: haacked
   url: 'https://github.com/haacked'
-  image_url: 'https://github.com/haacked.png?size=48'
+  image_url: 'https://github.com/haacked.png?size=96'
 slug: september-2016-roundup
 ---
 Here are the new Electron apps and talks that were added to the site in September.

--- a/blog/simple-samples.md
+++ b/blog/simple-samples.md
@@ -4,7 +4,7 @@ date: 2017-01-19T00:00:00.000Z
 authors:
   name: zeke
   url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=48'
+  image_url: 'https://github.com/zeke.png?size=96'
 slug: simple-samples
 ---
 We recently hosted an Electron hackathon at GitHub HQ for members of [Hackbright Academy](https://hackbrightacademy.com), a coding school for women founded in San Francisco. To help attendees get a head start on their projects, our own [Kevin Sawicki](https://github.com/kevinsawicki) created a few sample Electron applications.

--- a/blog/touch-bar-support.md
+++ b/blog/touch-bar-support.md
@@ -4,7 +4,7 @@ date: 2017-03-08T00:00:00.000Z
 authors:
   name: kevinsawicki
   url: 'https://github.com/kevinsawicki'
-  image_url: 'https://github.com/kevinsawicki.png?size=48'
+  image_url: 'https://github.com/kevinsawicki.png?size=96'
 slug: touch-bar-support
 ---
 The Electron [1.6.3] beta release contains initial support for the macOS [Touch Bar].

--- a/blog/typescript.md
+++ b/blog/typescript.md
@@ -4,7 +4,7 @@ date: 2017-06-01T00:00:00.000Z
 authors:
   name: zeke
   url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=48'
+  image_url: 'https://github.com/zeke.png?size=96'
 slug: typescript
 ---
 The `electron` npm package now includes a TypeScript definition file that provides detailed annotations of the entire Electron API. These annotations can improve your Electron development

--- a/blog/userland.md
+++ b/blog/userland.md
@@ -4,7 +4,7 @@ date: 2016-12-20T00:00:00.000Z
 authors:
   name: zeke
   url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=48'
+  image_url: 'https://github.com/zeke.png?size=96'
 slug: userland
 ---
 We've added a new [userland](https://electronjs.org/userland) section to

--- a/blog/voltra.md
+++ b/blog/voltra.md
@@ -4,13 +4,13 @@ date: 2017-03-07T00:00:00.000Z
 authors:
   - name: '0x00A'
     url: 'https://github.com/0x00A'
-    image_url: 'https://github.com/0x00A.png?size=48'
+    image_url: 'https://github.com/0x00A.png?size=96'
   - name: aprileelcich
     url: 'https://github.com/aprileelcich'
-    image_url: 'https://github.com/aprileelcich.png?size=48'
+    image_url: 'https://github.com/aprileelcich.png?size=96'
   - name: zeke
     url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=48'
+    image_url: 'https://github.com/zeke.png?size=96'
 slug: voltra
 ---
 This week we met with [Aprile Elcich](https://twitter.com/aprileelcich) and

--- a/blog/web-preferences-fix.md
+++ b/blog/web-preferences-fix.md
@@ -4,7 +4,7 @@ date: 2018-08-22T00:00:00.000Z
 authors:
   name: ckerr
   url: 'https://github.com/ckerr'
-  image_url: 'https://github.com/ckerr.png?size=48'
+  image_url: 'https://github.com/ckerr.png?size=96'
 slug: web-preferences-fix
 ---
 A remote code execution vulnerability has been discovered affecting apps with the ability to open nested child windows on Electron versions (3.0.0-beta.6, 2.0.7, 1.8.7, and 1.7.15). This vulnerability has been assigned the CVE identifier [CVE-2018-15685].

--- a/blog/website-hiccups.md
+++ b/blog/website-hiccups.md
@@ -4,7 +4,7 @@ date: 2018-02-12T00:00:00.000Z
 authors:
   name: zeke
   url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=48'
+  image_url: 'https://github.com/zeke.png?size=96'
 slug: website-hiccups
 ---
 Last week the [electronjs.org](https://electronjs.org) site had a few minutes

--- a/blog/webtorrent.md
+++ b/blog/webtorrent.md
@@ -4,10 +4,10 @@ date: 2017-03-14T00:00:00.000Z
 authors:
   - name: feross
     url: 'https://github.com/feross'
-    image_url: 'https://github.com/feross.png?size=48'
+    image_url: 'https://github.com/feross.png?size=96'
   - name: zeke
     url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=48'
+    image_url: 'https://github.com/zeke.png?size=96'
 slug: webtorrent
 ---
 This week we caught up with [@feross](https://github.com/feross) and [@dcposch](https://github.com/dcposch) to talk about WebTorrent, the web-powered torrent client that connects users together to form a distributed, decentralized browser-to-browser network.

--- a/blog/webview-fix.md
+++ b/blog/webview-fix.md
@@ -4,7 +4,7 @@ date: 2018-03-21T00:00:00.000Z
 authors:
   name: ckerr
   url: 'https://github.com/ckerr'
-  image_url: 'https://github.com/ckerr.png?size=48'
+  image_url: 'https://github.com/ckerr.png?size=96'
 slug: webview-fix
 ---
 A vulnerability has been discovered which allows Node.js integration to be re-enabled in some Electron applications that disable it. This vulnerability has been assigned the CVE identifier [CVE-2018-1000136](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000136).

--- a/blog/webview2.md
+++ b/blog/webview2.md
@@ -4,7 +4,7 @@ date: 2021-07-22T00:00:00.000Z
 authors:
   - name: electron
     url: 'https://github.com/electron'
-    image_url: 'https://github.com/electron.png?size=48'
+    image_url: 'https://github.com/electron.png?size=96'
 slug: webview2
 ---
 Over the past weeks, we’ve received several questions about the differences between the new [WebView2](https://docs.microsoft.com/en-us/microsoft-edge/webview2/) and Electron.

--- a/blog/window-open-fix.md
+++ b/blog/window-open-fix.md
@@ -4,7 +4,7 @@ date: 2019-02-03T00:00:00.000Z
 authors:
   name: ckerr
   url: 'https://github.com/ckerr'
-  image_url: 'https://github.com/ckerr.png?size=48'
+  image_url: 'https://github.com/ckerr.png?size=96'
 slug: window-open-fix
 ---
 A code vulnerability has been discovered that allows Node to be re-enabled in child windows.

--- a/blog/wordpress.md
+++ b/blog/wordpress.md
@@ -4,13 +4,13 @@ date: 2017-02-28T00:00:00.000Z
 authors:
   - name: mkaz
     url: 'https://github.com/mkaz'
-    image_url: 'https://github.com/mkaz.png?size=48'
+    image_url: 'https://github.com/mkaz.png?size=96'
   - name: johngodley
     url: 'https://github.com/johngodley'
-    image_url: 'https://github.com/johngodley.png?size=48'
+    image_url: 'https://github.com/johngodley.png?size=96'
   - name: zeke
     url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=48'
+    image_url: 'https://github.com/zeke.png?size=96'
 slug: wordpress
 ---
 This week we caught up with folks at [Automattic](https://automattic.com/) to

--- a/scripts/process-posts.js
+++ b/scripts/process-posts.js
@@ -17,7 +17,7 @@ const createAuthor = (author) => {
   return {
     name: author,
     url: `https://github.com/${author}`,
-    image_url: `https://github.com/${author}.png?size=48`,
+    image_url: `https://github.com/${author}.png?size=96`,
   };
 };
 


### PR DESCRIPTION
The author avatar photos look really low-def in the new blog, upping the requested size to 96px instead of 48px makes them look so much better.