### PR TITLE
fix: respect system color theme (dark/light)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,6 +18,10 @@ module.exports = {
     locales: ['en', 'de', 'es', 'fr', 'ja', 'pt', 'ru', 'zh'],
   },
   themeConfig: {
+    colorMode: {
+      //Default to light or dark depending on system theme.
+      respectPrefersColorScheme: true,
+    },
     navbar: {
       title: 'Electron',
       logo: {


### PR DESCRIPTION
## What does this PR do?

Fixes #114 

## Description of the change

Adds ```respectPrefersColorScheme: true``` property in [docusaurus.config.js](https://github.com/electron/electronjs.org-new/blob/main/docusaurus.config.js) which sets the website to use Light or Dark theme according to the System theme on the first load of the website.

Reference: https://docusaurus.io/docs/api/themes/configuration

## Demo

https://user-images.githubusercontent.com/55079486/137192868-38cabeb2-f334-4c01-a8f9-1aaa1d320d28.mp4

 
