### PR TITLE
fix: navbar link to homepage

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,6 +27,9 @@ module.exports = {
       logo: {
         alt: 'Electron homepage',
         src: 'assets/img/logo.svg',
+        // TODO: This can be removed when the SPA root homepage is working
+        href: 'https://electronjs.org',
+        target: '_self',
       },
       items: [
         {


### PR DESCRIPTION
I humbly request that we add this for now, so that clicking the Electron icon takes you to the real homepage, and not the SPA placeholder.