### PR TITLE
style: make code highlight color theme-dependent

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -53,10 +53,14 @@
 }
 
 .docusaurus-highlight-code-line {
-  background-color: rgb(72, 77, 91);
+  background-color: rgb(217, 220, 222);
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
+
+  :root[data-theme='dark'] & {
+    background-color: rgb(13, 15, 28);
+  }
 }
 
 .navbar {


### PR DESCRIPTION
![code highlight light mode](https://user-images.githubusercontent.com/16010076/138008693-e190d4cf-a10d-402b-8eb7-ef49cb298249.png)
![code highlight dark mode](https://user-images.githubusercontent.com/16010076/138008708-38a6a0e1-adbd-48ea-97e5-e695d9a1a70f.png)
