### PR TITLE
fix: clean up custom TOC implementation

### DIFF
--- a/src/theme/TOC/index.js
+++ b/src/theme/TOC/index.js
@@ -14,10 +14,8 @@
 import React from 'react';
 
 //@ts-expect-error
-import OriginalTOC, { TOCHeadings } from '@theme-original/TOC';
+import OriginalTOC from '@theme-original/TOC';
 import { cleanTOC } from '../../util/cleanHeadings';
-
-export { TOCHeadings };
 
 function TOC(props) {
   const cleanedTOC = cleanTOC(props.toc);

--- a/src/util/cleanHeadings.js
+++ b/src/util/cleanHeadings.js
@@ -26,7 +26,7 @@ function cleanHeading(str) {
   // For events: `Event: 'close'` becomes `close`
   const eventsMatch = str.match(/Event: &#39;([a-z]*(?:-[a-z]+)*)&#39;/)
   // For properties / methods: `win.previewFile(path[, displayName]) macOS` becomes `previewFile`
-  const propsMethodsMatch = str.match(/^<code>[a-zA-Z]+\.((?:[a-zA-Z]+[\.]?)+)/)
+  const propsMethodsMatch = str.match(/^<code>[a-zA-Z]+\.((?:[a-zA-Z0-9]+[\.]?)+)/)
   if (eventsMatch) {
     return `<code>'${eventsMatch[1]}'</code>`
   } else if (propsMethodsMatch) {


### PR DESCRIPTION
Two tiny changes:
* `src/theme/TOC/index.js`: The `TOCHeadings` component was removed from the `@theme/TOC` exports so I'm removing it here.
* `src/util/cleanHeadings.js`: Sometimes APIs have numbers in them (e.g. `app.runningUnderARM64Translation`). This PR fixes the TOC cleaning regex to take numbers into account.