### PR TITLE
Workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,92 @@
+# Reusable workflow for building and deploying the website
+# https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
+name: Build And Deploy
+
+on:
+  workflow_call:
+    inputs:
+      locale:
+        description: 'Identifier for the locale to build'
+        default: ''
+        required: false
+        type: string
+      branch:
+        description: 'If we are in "main" or a "version" docs branch'
+        required: true
+        type: string
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      SAS:
+        required: true
+
+jobs:
+  build_and_deploy:
+    name: Build and deploy the website
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set GIT_BRANCH
+        run: |
+          echo "GIT_BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Print branch if version
+        if: ${{ inputs.branch == 'version' }}
+        run: echo ${{ inputs.branch }}
+      - name: Print branch if main
+        if: ${{ inputs.branch == 'main' }}
+        run: echo ${{ inputs.branch }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Install dependencies
+        uses: bahmutov/npm-install@HEAD
+      - name: Test
+        run: yarn test
+        env:
+          CI: true
+      - name: Download cache
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 60
+          max_attempts: 3
+          retry_on: error
+          command: ./scripts/bin/azcopy copy "https://electronjsorg.blob.core.windows.net/%24web/*?$SAS" "./build" --recursive
+        env:
+          SAS: ${{ secrets.SAS }}
+      - name: Rewrite docs paths if version branch
+        if: ${{ inputs.branch == 'version' }}
+        run: node scripts/build-as-doc-version.js ${GIT_BRANCH}
+      - name: Build site for locale
+        run: yarn i18n:build ${{ inputs.locale }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish "/assets" to Storage if version branch
+        if: ${{ inputs.branch == 'version' }}
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 60
+          max_attempts: 3
+          retry_on: error
+          command: ./scripts/bin/azcopy copy "./build/assets/*" "https://electronjsorg.blob.core.windows.net/%24web/assets?$SAS" --recursive
+        env:
+          SAS: ${{ secrets.SAS }}
+      - name: Publish "/docs" to Storage if version branch
+        if: ${{ inputs.branch == 'version' }}
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 60
+          max_attempts: 3
+          retry_on: error
+          command: ./scripts/bin/azcopy copy "./build/docs/*" "https://electronjsorg.blob.core.windows.net/%24web/docs?$SAS" --recursive
+        env:
+          SAS: ${{ secrets.SAS }}
+      - name: Publish everything to Storage if main branch
+        if: ${{ inputs.branch == 'main' }}
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 60
+          max_attempts: 3
+          retry_on: error
+          command: ./scripts/bin/azcopy copy "./build/*" "https://electronjsorg.blob.core.windows.net/%24web/?$SAS" --recursive
+        env:
+          SAS: ${{ secrets.SAS }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Pull request
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  tests:
+  test:
     name: Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -1,4 +1,4 @@
-name: Push main
+name: Push and publish main
 
 on:
   push:
@@ -6,8 +6,9 @@ on:
       - main
 
 jobs:
-  tests:
-    name: Test and Deploy
+# Make a reusable workflow
+  crowdin-upload:
+    name: Upload to Crowdin
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,26 +18,16 @@ jobs:
           node-version: 14
       - name: Install dependencies
         uses: bahmutov/npm-install@HEAD
-
       - name: Upload sources to Crowdin
         run: 'yarn i18n:upload'
         env:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
-      - name: Test
-        run: yarn test
-        env:
-          CI: true
-
-      - name: Download cache
-        run: ./scripts/bin/azcopy copy "https://electronjsorg.blob.core.windows.net/%24web/*?$SAS" "./build" --recursive
-        env:
-          SAS: ${{ secrets.SAS }}
-
-      - name: Build EN
-        run: yarn i18n:build en
-
-      - name: Deploy
-        run: ./scripts/bin/azcopy copy "./build/*" "https://electronjsorg.blob.core.windows.net/%24web?$SAS" --recursive
-        env:
-          SAS: ${{ secrets.SAS }}
+  build-and-deploy:
+    uses: electron/electronjs.org-new/.github/workflows/build-and-deploy.yml@main
+    with:
+      locale: en
+      branch: main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SAS: ${{ secrets.SAS }}

--- a/.github/workflows/push-others.yml
+++ b/.github/workflows/push-others.yml
@@ -1,4 +1,4 @@
-name: Push on version branch
+name: Push and publish version branch
 
 on:
   push:
@@ -6,33 +6,11 @@ on:
       - 'v**'
 
 jobs:
-  tests:
-    name: Push updates to previous versions
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set environment variables
-        run: |
-          echo "GIT_BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v2
-      - name: Use Node.js 14
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-      - name: Install dependencies
-        uses: bahmutov/npm-install@HEAD
-
-      - name: 'Build branch version (EN)'
-        run: |
-          node scripts/build-as-doc-version.js ${GIT_BRANCH}
-          yarn i18n:build en
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'Publish Assets to Storage'
-        run: ./scripts/bin/azcopy copy "./build/assets/*" "https://electronjsorg.blob.core.windows.net/%24web/assets?$SAS" --recursive
-        env:
-          SAS: ${{ secrets.SAS }}
-      - name: 'Publish docs to Storage'
-        run: ./scripts/bin/azcopy copy "./build/docs/*" "https://electronjsorg.blob.core.windows.net/%24web/docs?$SAS" --recursive
-        env:
-          SAS: ${{ secrets.SAS }}
+  build-and-deploy:
+    uses: electron/electronjs.org-new/.github/workflows/build-and-deploy.yml@main
+    with:
+      locale: en
+      branch: version
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SAS: ${{ secrets.SAS }}

--- a/.github/workflows/update-docs-branch.yml
+++ b/.github/workflows/update-docs-branch.yml
@@ -1,4 +1,4 @@
-name: 'Update docs'
+name: 'Update docs branch'
 
 on:
   repository_dispatch:
@@ -7,19 +7,35 @@ on:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.branch.outputs.branch }}
     steps:
       - uses: actions/checkout@v2
+      - name: 'Switch branches'
+        # We switch to the version branch or create a new one if needed
+        run: git fetch origin && git checkout -t origin/v${{ github.event.client_payload.branch}} || git checkout -b v${{ github.event.client_payload.branch}}
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - name: 'Switch branches'
-# We switch to the version branch or create a new one if needed
-        run: git fetch origin && git checkout -t origin/v${{ github.event.client_payload.branch}} || git checkout -b v${{ github.event.client_payload.branch}}
       - name: Install dependencies
-        run: 'yarn'
+        uses: bahmutov/npm-install@HEAD
       - name: 'Prebuild'
         run: 'yarn pre-build ${{ github.event.client_payload.sha }}'
       - name: 'Push changes or create PR'
         run: 'yarn process-docs-changes'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: branch
+        run: echo "::set-output name=branch::`git branch --show-current'
+  # GitHub will not kick the "push-XXX" workflow so we have to publish from here
+  build-and-deploy:
+    needs: [update-docs]
+    # If we are in a version branch, it means we have pushed the changed directly and should deploy
+    if: ${{ needs.branch.outputs.branch =~ ^v[0-9]+-x-y$ }}
+    uses: electron/electronjs.org-new/.github/workflows/build-and-deploy.yml@main
+    with:
+      locale: en
+      branch: version
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SAS: ${{ secrets.SAS }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -7,16 +7,32 @@ on:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.branch.outputs.branch }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
       - name: Install dependencies
-        run: 'yarn'
-      - name: 'Download docs'
+        uses: bahmutov/npm-install@HEAD
+      - name: 'Prebuild'
         run: 'yarn pre-build ${{ github.event.client_payload.sha }} ${{ github.event.client_payload.branch}}'
       - name: 'Push changes or create PR'
         run: 'yarn process-docs-changes'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: branch
+        run: echo "::set-output name=branch::`git branch --show-current'
+  # GitHub will not kick the "push-XXX" workflow so we have to publish from here
+  build-and-deploy:
+    needs: [update-docs]
+    # If we are in the "main" branch, it means we have pushed the changed directly and should deploy
+    if: ${{ needs.branch.outputs.branch == 'main' }}
+    uses: electron/electronjs.org-new/.github/workflows/build-and-deploy.yml@main
+    with:
+      locale: en
+      branch: main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SAS: ${{ secrets.SAS }}


### PR DESCRIPTION
GitHub will not trigger a workflow from an action that happened in
another workflow. This change adds "reusable workflows" so the
deployment can happen when there is a `push` as well as when there is a
`docs_update` that changes the content.

It also adds a few improvements:

- Better naming of flows and steps
- Parallelize the upload to Crowdin to speed up performance
- Auto-retry operations with Azure Storage in case they fail
- Move all the build and deployment logic to `build-and-deploy.yml` with
  conditional steps that check if the current branch is `main` or a
  `version` one

-----------------

I have tested the `push` events in in my fork and they seem to be working OK. [Here is an example](https://github.com/molant/electronjs.org-new/runs/4038319545?check_suite_focus=true) before squashing in main (Crowdin fails because I didn't add the token).

One thing to know is that there might be some validation errors in the yml until this is merged. The reason is that to reference a reusable workflow we need to indicate the `user/repo` as well as the branch. I've updated the references to be `electron/electronjs.org-new` and `main` but those files do not exist yet until this is merged so they won't be found (I run into this before...).