### PR TITLE
build: remove `GITHUB_TOKEN` from user secrets

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,8 +15,6 @@ on:
         required: true
         type: string
     secrets:
-      GITHUB_TOKEN:
-        required: true
       SAS:
         required: true
 


### PR DESCRIPTION
We've been getting errors in  many of our workflows recently with the following errors:

```
workflow is invalid: secret name `GITHUB_TOKEN` within `workflow_call` can not be used since it would collide with system reserved name
```

See: https://github.com/electron/electronjs.org-new/actions/runs/1651559030

I think this change makes sense as per GitHub's ["Automatic token authentication"](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) documentation.

> An action can access the GITHUB_TOKEN through the github.token context even if the workflow does not explicitly pass the GITHUB_TOKEN to the action. 

I'm guessing this is because the GITHUB_TOKEN is being provided by Actions and we don't need to provide it in the `secrets` field. Cherry-picking this commit onto the other branch prevents the error from occurring.