### PR TITLE
build: remove GITHUB_TOKEN from update secrets

### DIFF
--- a/.github/workflows/update-docs-branch.yml
+++ b/.github/workflows/update-docs-branch.yml
@@ -41,5 +41,4 @@ jobs:
       locale: en
       branch: version
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SAS: ${{ secrets.SAS }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -34,5 +34,4 @@ jobs:
       locale: en
       branch: main
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SAS: ${{ secrets.SAS }}


### PR DESCRIPTION
Looks like the `update_docs` action is encountering issues.

Ref #156