### PR TITLE
fix(prebuild): only prefix electron docs

### DIFF
--- a/docs/latest/api/content-tracing.md
+++ b/docs/latest/api/content-tracing.md
@@ -90,4 +90,4 @@ Returns `Promise<Object>` - Resolves with an object containing the `value` and `
 Get the maximum usage across processes of trace buffer as a percentage of the
 full state.
 
-[trace viewer]: latest/development/README.md
+[trace viewer]: https://chromium.googlesource.com/catapult/+/HEAD/tracing/README.md

--- a/docs/latest/api/crash-reporter.md
+++ b/docs/latest/api/crash-reporter.md
@@ -40,7 +40,7 @@ underneath the app's user data directory, called 'Crashpad'. You can override
 this directory by calling `app.setPath('crashDumps', '/path/to/crashes')`
 before starting the crash reporter.
 
-Electron uses [crashpad](latest/development/README.md)
+Electron uses [crashpad](https://chromium.googlesource.com/crashpad/crashpad/+/refs/heads/main/README.md)
 to monitor and report crashes.
 
 ## Methods

--- a/docs/latest/api/structures/trace-config.md
+++ b/docs/latest/api/structures/trace-config.md
@@ -55,4 +55,4 @@ An example TraceConfig that roughly matches what Chrome DevTools records:
 [tracing categories]: https://chromium.googlesource.com/chromium/src/+/master/base/trace_event/builtin_categories.h
 [memory-infra docs]: https://chromium.googlesource.com/chromium/src/+/master/docs/memory-infra/memory_infra_startup_tracing.md#the-advanced-way
 [trace_event_args_whitelist.cc]: https://chromium.googlesource.com/chromium/src/+/master/services/tracing/public/cpp/trace_event_args_whitelist.cc
-[histogram]: latest/development/README.md
+[histogram]: https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histograms/README.md

--- a/docs/latest/development/coding-style.md
+++ b/docs/latest/development/coding-style.md
@@ -32,7 +32,7 @@ You can run `npm run lint` to show any style issues detected by `cpplint` and
 ## C++ and Python
 
 For C++ and Python, we follow Chromium's [Coding
-Style](latest/styleguide.md). You can use
+Style](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/styleguide/styleguide.md). You can use
 [clang-format](latest/development/clang-format.md) to format the C++ code automatically. There is
 also a script `script/cpplint.py` to check whether all files conform.
 

--- a/docs/latest/tutorial/installation.md
+++ b/docs/latest/tutorial/installation.md
@@ -201,8 +201,8 @@ If you need to force a re-download of the asset and the SHASUM file set the
 [versioning]: latest/tutorial/electron-versioning.md
 [npx]: https://docs.npmjs.com/cli/v7/commands/npx
 [releases]: https://github.com/electron/electron/releases
-[proxy-env-10]: latest/development/README.md#environment-variables
-[proxy-env]: latest/development/README.md#auto-config
+[proxy-env-10]: https://github.com/gajus/global-agent/blob/v2.1.5/README.md#environment-variables
+[proxy-env]: https://github.com/np-maintain/global-tunnel/blob/v2.7.1/README.md#auto-config
 [electron-get]: https://github.com/electron/get
 [npm-permissions]: https://docs.npmjs.com/getting-started/fixing-npm-permissions
 [unsafe-perm]: https://docs.npmjs.com/misc/config#unsafe-perm

--- a/docs/latest/tutorial/notifications.md
+++ b/docs/latest/tutorial/notifications.md
@@ -156,4 +156,4 @@ GNOME, KDE.
 [notification-spec]: https://developer.gnome.org/notification-spec/
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [set-app-user-model-id]: latest/api/app.md#appsetappusermodelidid-windows
-[squirrel-events]: latest/development/README.md#handling-squirrel-events
+[squirrel-events]: https://github.com/electron/windows-installer/blob/master/README.md#handling-squirrel-events

--- a/docs/latest/tutorial/sandbox.md
+++ b/docs/latest/tutorial/sandbox.md
@@ -164,7 +164,7 @@ versions of Electron, we do not make a guarantee that every fix will be
 backported. Your best chance at staying secure is to be on the latest stable
 version of Electron.
 
-[sandbox]: latest/tutorial/sandbox.md
+[sandbox]: https://chromium.googlesource.com/chromium/src/+/master/docs/design/sandbox.md
 [issue-28466]: https://github.com/electron/electron/issues/28466
 [browser-window]: latest/api/browser-window.md
 [enable-sandbox]: latest/api/app.md#appenablesandbox

--- a/scripts/tasks/md-fixers.js
+++ b/scripts/tasks/md-fixers.js
@@ -148,10 +148,20 @@ const fixLinks = (content, linksMaps) => {
 
   while ((val = mdLinkRegex.exec(content)) !== null) {
     const link = val[2];
-    const basename = path.basename(link);
+
+    // Don't map links from outside the electron docs
+    if (
+      link.startsWith('https://') &&
+      !link.includes('github.com/electron/electron/')
+    ) {
+      continue;
+    }
+
     // Link could be `glossary.md#main-process` and we just need `glossary.md`
+    const basename = path.basename(link);
     const parts = basename.split('#');
     const key = parts.shift();
+
     if (linksMaps.has(key)) {
       const newLink = [linksMaps.get(key), ...parts];
       const replacement = val[0].replace(val[2], newLink.join('#'));


### PR DESCRIPTION
Fixes #161

We map any link with a `path.basename` matching an existing Electron doc to that Electron doc. This is a hack because we force the docs to have `/latest` in their URL. This causes links with common names such as `README.md` to get mapped to the Electron link by accident.