### PR TITLE
style: tone down colours for API structure tooltips

### DIFF
--- a/src/components/APIStructurePreview.module.scss
+++ b/src/components/APIStructurePreview.module.scss
@@ -1,6 +1,7 @@
 .link {
+  --tooltip-color: var(--ifm-color-primary-dark);
   display: inline-block;
-  text-decoration-color: var(--electron-inline-code);
+  text-decoration-color: var(--tooltip-color);
   text-decoration-line: underline;
   text-decoration-style: dotted;
   text-underline-offset: 4px;
@@ -9,15 +10,15 @@
   overflow: visible;
 
   &::after {
-    content: '?';
-    color: var(--electron-inline-code);
-    border: 1px solid var(--electron-inline-code);
+    content: 'i';
+    color: var(--tooltip-color);
+    border: 1px solid var(--tooltip-color);
     border-radius: 20px;
     width: 1.6em;
     font-size: 50%;
     text-align: center;
     position: absolute;
-    left: 100%;
+    left: calc(100% + 0.1em);
     top: 0.5em;
     margin: 2px;
     display: flex;


### PR DESCRIPTION
Based on some internal feedback, this PR changes the colours of API structure tooltip indicators from red to blue to be less aggressive.