### PR TITLE
fix: admonitions from crowdin

### DIFF
--- a/scripts/tasks/md-fixers.js
+++ b/scripts/tasks/md-fixers.js
@@ -121,6 +121,7 @@ const transform = (doc) => {
     fiddleTransformer,
     newLineOnHTMLComment,
     newLineOnAdmonition,
+    fixAdmonitions,
   ];
 
   for (const line of lines) {
@@ -203,6 +204,20 @@ const fixLinks = (content, linksMaps) => {
   }
 
   return updatedContent;
+};
+
+/**
+ * Crowdin sometimes breaks the admonitions closing tags (`:::`)
+ * and puts them in the same line instead of a new one. This breaks
+ * the build process and times out our i18n deployment.
+ * @param {string} content 
+ * @returns 
+ */
+const fixAdmonitions = (content) => {
+  if (!line.startsWith(':::') && line.endsWith(':::')) {
+    return line.replace(':::', '\n:::');
+  }
+  return line;
 };
 
 /**

--- a/scripts/tasks/md-fixers.js
+++ b/scripts/tasks/md-fixers.js
@@ -210,10 +210,10 @@ const fixLinks = (content, linksMaps) => {
  * Crowdin sometimes breaks the admonitions closing tags (`:::`)
  * and puts them in the same line instead of a new one. This breaks
  * the build process and times out our i18n deployment.
- * @param {string} content 
+ * @param {string} line 
  * @returns 
  */
-const fixAdmonitions = (content) => {
+const fixAdmonitions = (line) => {
   if (!line.startsWith(':::') && line.endsWith(':::')) {
     return line.replace(':::', '\n:::');
   }

--- a/scripts/tasks/md-fixers.js
+++ b/scripts/tasks/md-fixers.js
@@ -210,8 +210,7 @@ const fixLinks = (content, linksMaps) => {
  * Crowdin sometimes breaks the admonitions closing tags (`:::`)
  * and puts them in the same line instead of a new one. This breaks
  * the build process and times out our i18n deployment.
- * @param {string} line 
- * @returns 
+ * @param {string} line
  */
 const fixAdmonitions = (line) => {
   if (!line.startsWith(':::') && line.endsWith(':::')) {


### PR DESCRIPTION
Crowdin sometimes breaks the admonitions closing tags (`:::`)
and puts them in the same line instead of a new one. This breaks
the build process and times out our i18n deployment.