### PR TITLE
feat: added shorthand to preset

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -168,7 +168,7 @@ module.exports = {
   plugins: ['docusaurus-plugin-sass'],
   presets: [
     [
-      '@docusaurus/preset-classic',
+      'classic',
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),


### PR DESCRIPTION
The docusaurus.config file has been supporting `module shorthands` , and electrons docusaurus config is following the same, the preset was not using it ,so i made it shorthand