### PR TITLE
feat: added configuration for author and time updated

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -173,6 +173,8 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           routeBasePath: '/docs/',
+          showLastUpdateAuthor: true,
+          showLastUpdateTime: true,
           editUrl: ({ docPath }) => {
             // TODO: remove when `latest/` is no longer hardcoded
             const fixedPath = docPath.replace('latest/', '');


### PR DESCRIPTION
I have added a small configuration which is available to docusaurus , it shows the author name who last updated the doc and the time

![Notifications _ Electron - Google Chrome 3_9_2022 1_05_51 PM](https://user-images.githubusercontent.com/72331432/157394556-3aeed6b2-9b1d-4c96-a249-a84db1eefd63.png)

