### PR TITLE
fix: admonitions for crowdin

### DIFF
--- a/blog/12-week-cadence.md
+++ b/blog/12-week-cadence.md
@@ -14,6 +14,7 @@ In Q3 2021, the Chrome team [increased their release cadence](https://blog.chrom
 from every 6 weeks to every 4 weeks. Electron's releases have followed suit.
 Please read the updated [8 week cadence](./8-week-cadence.md) blog post
 for more up-to-date information!
+
 :::
 
 🎉 Electron is moving to release a new major stable version every 12 weeks! 🎉

--- a/docs/latest/tutorial/automated-testing.md
+++ b/docs/latest/tutorial/automated-testing.md
@@ -146,14 +146,18 @@ npm install --save-dev @playwright/test
 ```
 
 :::caution Dependencies
+
 This tutorial was written `playwright@1.16.3` and `@playwright/test@1.16.3`. Check out
 [Playwright's releases][playwright-releases] page to learn about
 changes that might affect the code below.
+
 :::
 
 :::info Using third-party test runners
+
 If you're interested in using an alternative test runner (e.g. Jest or Mocha), check out
 Playwright's [Third-Party Test Runner][playwright-test-runners] guide.
+
 :::
 
 ### Write your tests
@@ -248,13 +252,17 @@ Running 1 test using 1 worker
 ```
 
 :::info
+
 Playwright Test will automatically run any files matching the `.*(test|spec)\.(js|ts|mjs)` regex.
 You can customize this match in the [Playwright Test configuration options][playwright-test-config].
+
 :::
 
 :::tip Further reading
+
 Check out Playwright's documentation for the full [Electron][playwright-electron]
 and [ElectronApplication][playwright-electronapplication] class APIs.
+
 :::
 
 ## Using a custom test driver

--- a/docs/latest/tutorial/ipc.md
+++ b/docs/latest/tutorial/ipc.md
@@ -84,7 +84,9 @@ find the BrowserWindow instance attached to the message sender and use the `win.
 API on it.
 
 :::info
+
 Make sure you're loading the `index.html` and `preload.js` entry points for the following steps!
+
 :::
 
 ### 2. Expose `ipcRenderer.send` via preload
@@ -108,8 +110,10 @@ At this point, you'll be able to use the `window.electronAPI.setTitle()` functio
 process.
 
 :::caution Security warning
+
 We don't directly expose the whole `ipcRenderer.send` API for [security reasons]. Make sure to
 limit the renderer's access to Electron APIs as much as possible.
+
 :::
 
 ### 3. Build the renderer process UI
@@ -175,10 +179,12 @@ channel from the renderer process. The return value is then returned as a Promis
 `invoke` call.
 
 :::caution A word on error handling
+
 Errors thrown through `handle` in the main process are not transparent as they
 are serialized and only the `message` property from the original error is
 provided to the renderer process. Please refer to
 [#24427](https://github.com/electron/electron/issues/24427) for details.
+
 :::
 
 ```javascript {6-13,25} title='main.js (Main Process)'
@@ -213,12 +219,16 @@ app.whenReady(() => {
 ```
 
 :::tip on channel names
+
 The `dialog:` prefix on the IPC channel name has no effect on the code. It only serves
 as a namespace that helps with code readability.
+
 :::
 
 :::info
+
 Make sure you're loading the `index.html` and `preload.js` entry points for the following steps!
+
 :::
 
 ### 2. Expose `ipcRenderer.invoke` via preload
@@ -236,8 +246,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
 ```
 
 :::caution Security warning
+
 We don't directly expose the whole `ipcRenderer.invoke` API for [security reasons]. Make sure to
 limit the renderer's access to Electron APIs as much as possible.
+
 :::
 
 ### 3. Build the renderer process UI
@@ -286,13 +298,17 @@ IPC from the renderer process. However, there exist a couple alternative approac
 pattern.
 
 :::warning Avoid legacy approaches if possible
+
 We recommend using `ipcRenderer.invoke` whenever possible. The following two-way renderer-to-main
 patterns are documented for historical purposes.
+
 :::
 
 :::info
+
 For the following examples, we're calling `ipcRenderer` directly from the preload script to keep
 the code samples small.
+
 :::
 
 #### Using `ipcRenderer.send`
@@ -420,7 +436,9 @@ click: () => mainWindow.webContents.send('update-counter', -1)
 ```
 
 :::info
+
 Make sure you're loading the `index.html` and `preload.js` entry points for the following steps!
+
 :::
 
 ### 2. Expose `ipcRenderer.on` via preload
@@ -440,11 +458,14 @@ After loading the preload script, your renderer process should have access to th
 `window.electronAPI.onUpdateCounter()` listener function.
 
 :::caution Security warning
+
 We don't directly expose the whole `ipcRenderer.on` API for [security reasons]. Make sure to
 limit the renderer's access to Electron APIs as much as possible.
+
 :::
 
 :::info
+
 In the case of this minimal example, you can call `ipcRenderer.on` directly in the preload script
 rather than exposing it over the context bridge.
 
@@ -463,6 +484,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
 However, this approach has limited flexibility compared to exposing your preload APIs
 over the context bridge, since your listener can't directly interact with your renderer code.
+
 :::
 
 ### 3. Build the renderer process UI

--- a/docs/latest/tutorial/security.md
+++ b/docs/latest/tutorial/security.md
@@ -8,12 +8,14 @@ toc_max_heading_level: 3
 # Security
 
 :::info Reporting security issues
+
 For information on how to properly disclose an Electron vulnerability,
 see [SECURITY.md](https://github.com/electron/electron/tree/main/SECURITY.md).
 
 For upstream Chromium vulnerabilities: Electron keeps up to date with alternating
 Chromium releases. For more information, see the
 [Electron Release Timelines](latest/tutorial/electron-timelines.md) document.
+
 :::
 
 ## Preface
@@ -76,14 +78,17 @@ source directly, or by sitting between your app and the actual destination), the
 will be able to execute native code on the user's machine.
 
 :::warning
+
 Under no circumstances should you load and execute remote code with
 Node.js integration enabled. Instead, use only local files (packaged together
 with your application) to execute Node.js code. To display remote content, use
 the [`<webview>`][webview-tag] tag or [`BrowserView`][browser-view], make sure
 to disable the `nodeIntegration` and enable `contextIsolation`.
+
 :::
 
 :::info Electron security warnings
+
 Security warnings and recommendations are printed to the developer console.
 They only show up when the binary's name is Electron, indicating that a developer
 is currently looking at the console.
@@ -91,6 +96,7 @@ is currently looking at the console.
 You can force-enable or force-disable these warnings by setting
 `ELECTRON_ENABLE_SECURITY_WARNINGS` or `ELECTRON_DISABLE_SECURITY_WARNINGS` on
 either `process.env` or the `window` object.
+
 :::
 
 ## Checklist: Security recommendations
@@ -163,7 +169,9 @@ browserWindow.loadURL('https://example.com')
 ### 2. Do not enable Node.js integration for remote content
 
 :::info
+
 This recommendation is the default behavior in Electron since 5.0.0.
+
 :::
 
 It is paramount that you do not enable Node.js integration in any renderer
@@ -228,7 +236,9 @@ API to remotely loaded content via the [contextBridge API](latest/api/context-br
 ### 3. Enable Context Isolation for remote content
 
 :::info
+
 This recommendation is the default behavior in Electron since 12.0.0.
+
 :::
 
 Context isolation is an Electron feature that allows developers to run code
@@ -243,8 +253,10 @@ Even when `nodeIntegration: false` is used, to truly enforce strong isolation
 and prevent the use of Node primitives `contextIsolation` **must** also be used.
 
 :::info
+
 For more information on what `contextIsolation` is and how to enable it please
 see our dedicated [Context Isolation](latest/tutorial/context-isolation.md) document.
+
 :::info
 
 ### 4. Enable process sandboxing
@@ -256,8 +268,10 @@ the sandbox in all renderers. Loading, reading or processing any untrusted
 content in an unsandboxed process, including the main process, is not advised.
 
 :::info
+
 For more information on what `contextIsolation` is and how to enable it please
 see our dedicated [Process Sandboxing](latest/tutorial/sandbox.md) document.
+
 :::info
 
 ### 5. Handle session permission requests from remote content
@@ -301,7 +315,9 @@ session
 ### 6. Do not disable `webSecurity`
 
 :::info
+
 This recommendation is Electron's default.
+
 :::
 
 You may have already guessed that disabling the `webSecurity` property on a
@@ -402,7 +418,9 @@ be useful in some cases to set a policy on a page directly in the markup using a
 ### 8. Do not enable `allowRunningInsecureContent`
 
 :::info
+
 This recommendation is Electron's default.
+
 :::
 
 By default, Electron will not allow websites loaded over `HTTPS` to load and
@@ -437,7 +455,9 @@ const mainWindow = new BrowserWindow({})
 ### 9. Do not enable experimental features
 
 :::info
+
 This recommendation is Electron's default.
+
 :::
 
 Advanced users of Electron can enable experimental Chromium features using the
@@ -471,7 +491,9 @@ const mainWindow = new BrowserWindow({})
 ### 10. Do not use `enableBlinkFeatures`
 
 :::info
+
 This recommendation is Electron's default.
+
 :::
 
 Blink is the name of the rendering engine behind Chromium. As with
@@ -505,7 +527,9 @@ const mainWindow = new BrowserWindow()
 ### 11. Do not use `allowpopups` for WebViews
 
 :::info
+
 This recommendation is Electron's default.
+
 :::
 
 If you are using [`<webview>`][webview-tag], you might need the pages and scripts

--- a/scripts/tasks/md-fixers.js
+++ b/scripts/tasks/md-fixers.js
@@ -94,14 +94,15 @@ const newLineOnHTMLComment = (line) => {
 };
 
 /**
- * Crowdin translations also happen to break
- * Docusaurus' MDX admonition syntax.
+ * Crowdin needs extra blank lines surrounding the admonition characters so it doesn't
+ * break Docusaurus with the translated content.
  * @param {string} line
  */
 const newLineOnAdmonition = (line) => {
-  if (line.endsWith(':::') && !line.startsWith(':::')) {
-    return line.replace(':::', ':::\n');
+  if (line.trim().startsWith(':::') || line.trim().endsWith(':::')) {
+    return `\n${line.trim()}\n`;
   }
+
   return line;
 };
 
@@ -206,6 +207,14 @@ const fixLinks = (content, linksMaps) => {
 };
 
 /**
+ * Removes unnecesary extra blank lines
+ * @param {string} content
+ */
+const fixReturnLines = (content) => {
+  return content.replace(/\n\n(\n)+/g, '\n\n');
+};
+
+/**
  * The current doc's format on `electron/electron` cannot be used
  * directly by docusaurus. This function trasform all the md files
  * found in the given `root` (recursively) and makes sure they are
@@ -233,9 +242,9 @@ const fixContent = async (root, version = 'latest') => {
 
     let fixedContent = transform(content);
 
-    // `fixLinks` analyzes the document globally instead of line by line, thus why
-    // it cannot be part of `transform`
-    fixedContent = fixLinks(fixedContent, linksMaps);
+    // `fixLinks` and `fixReturnLines` analyze the document globally instead
+    // of line by line, thus why it cannot be part of `transform`
+    fixedContent = fixReturnLines(fixLinks(fixedContent, linksMaps));
 
     await fs.writeFile(path.join(root, filePath), fixedContent, 'utf-8');
   }


### PR DESCRIPTION
This fixes the current spacing with the admonitions so Crowdin doesn't change the format and we can actually build the translated documents.

It also adds a new fixer just in case we don't add the spaces again upstream.