### PR TITLE
fix: Fiddle code fix and documentation changes

### DIFF
--- a/docs/latest/fiddles/ipc/pattern-3/main.js
+++ b/docs/latest/fiddles/ipc/pattern-3/main.js
@@ -1,4 +1,4 @@
-const {app, BrowserWindow, Menu} = require('electron')
+const {app, BrowserWindow, Menu, ipcMain} = require('electron')
 const path = require('path')
 
 function createWindow () {

--- a/docs/latest/fiddles/ipc/pattern-3/renderer.js
+++ b/docs/latest/fiddles/ipc/pattern-3/renderer.js
@@ -4,5 +4,5 @@ window.electronAPI.handleCounter((event, value) => {
     const oldValue = Number(counter.innerText)
     const newValue = oldValue + value
     counter.innerText = newValue
-    event.reply('counter-value', newValue)
+    event.sender.send('counter-value', newValue)
 })

--- a/docs/latest/tutorial/ipc.md
+++ b/docs/latest/tutorial/ipc.md
@@ -395,7 +395,7 @@ module that uses the `webContents.send` API to send an IPC message from the main
 target renderer.
 
 ```javascript {11-26} title='main.js (Main Process)'
-const {app, BrowserWindow, Menu} = require('electron')
+const {app, BrowserWindow, Menu, ipcMain} = require('electron')
 const path = require('path')
 
 function createWindow () {
@@ -541,7 +541,7 @@ window.electronAPI.onUpdateCounter((event, value) => {
   const oldValue = Number(counter.innerText)
   const newValue = oldValue + value
   counter.innerText = newValue
-  event.reply('counter-value', newValue)
+  event.sender.send('counter-value', newValue)
 })
 ```
 


### PR DESCRIPTION
Closes #189  

**What I did**
- imported `ipcMain` from electron.
- changed `event.reply` to `event.sender.send` as reply is not a function but sender.send() does the exact same thing.

I verified the fiddle is running and working fine without errors and warnings.