### PR TITLE
feat(md): add class name to `options` list items

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,6 +2,7 @@
 const npm2yarn = require('@docusaurus/remark-plugin-npm2yarn');
 const fiddleEmbedder = require('./src/transformers/fiddle-embedder.js');
 const apiLabels = require('./src/transformers/api-labels.js');
+const apiOptionsClass = require('./src/transformers/api-options-class.js');
 const apiStructurePreviews = require('./src/transformers/api-structure-previews.js');
 const docVersions = require('./versions-info.json');
 
@@ -181,6 +182,7 @@ module.exports = {
           },
           remarkPlugins: [
             apiLabels,
+            apiOptionsClass,
             apiStructurePreviews,
             fiddleEmbedder,
             [npm2yarn, { sync: true }],

--- a/src/transformers/api-options-class.js
+++ b/src/transformers/api-options-class.js
@@ -1,0 +1,37 @@
+//@ts-check
+
+/**
+ * This transformer adds the class="electron-api-options-list"
+ * to any <li> element that starts with <code>options</code>.
+ * This is for future use in the Algolia crawler to refine the
+ * number of list items we want to store in our search index.
+ */
+
+const visitParents = require('unist-util-visit-parents');
+
+module.exports = function attacher() {
+  return transformer;
+};
+
+const CLASS = 'electron-api-options-list';
+
+/**
+ *
+ * @param {import("unist").Parent} tree
+ */
+async function transformer(tree) {
+  visitParents(tree, 'listItem', visitor);
+}
+
+/**
+ *
+ * @param {import("unist").Node} node
+ */
+function visitor(node) {
+  if (
+    Array.isArray(node?.children[0]?.children) &&
+    node.children[0].children[0].value === 'options'
+  ) {
+    node.data = { hProperties: { className: [CLASS] } };
+  }
+}


### PR DESCRIPTION
This transformer adds `class="electron-api-options-list"`
to any \<li\> element that starts with <code>options</code>.
This is for future use in the Algolia crawler to refine the
number of list items we want to store in our search index.