### PR TITLE
chore: show crowdin download verbose log

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "crowdin": "crowdin",
     "i18n:upload": "crowdin upload sources",
-    "i18n:download": "crowdin download && node scripts/prepare-i18n-content.js",
+    "i18n:download": "crowdin download --verbose && node scripts/prepare-i18n-content.js",
     "i18n:build": "node scripts/i18n-build.js",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",


### PR DESCRIPTION
So that when a problem arises, it can be quickly located

#### Before:
<img width="1565" alt="image" src="https://user-images.githubusercontent.com/8198408/164270136-5b29f7a3-36cc-4ddb-9099-dd4eb63d9b74.png">

#### After:
<img width="1575" alt="图片" src="https://user-images.githubusercontent.com/8198408/164270358-3a693877-5f01-42fd-bd48-23309dce32ea.png">


