### PR TITLE
refactor: add utm params in url

### DIFF
--- a/src/pages/home/_components/AppsGrid.jsx
+++ b/src/pages/home/_components/AppsGrid.jsx
@@ -3,6 +3,9 @@ import Link from '@docusaurus/Link';
 import { useColorMode } from '@docusaurus/theme-common';
 import clsx from 'clsx';
 import styles from './AppsGrid.module.scss';
+import { addUTM } from '../../../util/addUTM';
+
+const utm = addUTM('home_page');
 
 export default function AppsGrid({ list }) {
   const { isDarkTheme } = useColorMode();
@@ -11,7 +14,7 @@ export default function AppsGrid({ list }) {
       <div className={styles.appsContainer}>
         {list.map((item) => (
           <a
-            href={item.href}
+            href={utm(item.href)}
             key={item.image}
             className={clsx(styles.appCard, 'card')}
           >

--- a/src/util/addUTM.js
+++ b/src/util/addUTM.js
@@ -1,0 +1,17 @@
+/**
+ *
+ * @param {string} utmMedium
+ * @returns {(urlAddress: string) => string}
+ */
+export function addUTM(utmMedium) {
+  /**
+   * @param {string} urlAddress
+   */
+  return function (urlAddress) {
+    const url = new URL(urlAddress);
+    url.searchParams.append('utm_source', 'electron');
+    url.searchParams.append('utm_medium', utmMedium);
+
+    return url.toString();
+  };
+}


### PR DESCRIPTION
Provide users of electron with more accurate analysis data. Let them know how many `PV/UV` are obtained through electron.
