### PR TITLE
style: make doc markdown links bold

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -137,7 +137,7 @@
 
 .markdown {
   a {
-    font-weight: var(--ifm-font-weight-semibold);
+    font-weight: var(--ifm-font-weight-bold);
   }
 
   h1,


### PR DESCRIPTION
Necessary for now because the font that we use for the monospace `code` in the docs does not come with a semi-bold (500 weight) version.