### PR TITLE
refactor: stop using deprecated `isDarkTheme` API

### DIFF
--- a/src/pages/home/_components/AppsGrid.jsx
+++ b/src/pages/home/_components/AppsGrid.jsx
@@ -5,7 +5,8 @@ import clsx from 'clsx';
 import styles from './AppsGrid.module.scss';
 
 export default function AppsGrid({ list }) {
-  const { isDarkTheme } = useColorMode();
+  const { colorMode } = useColorMode();
+  const isDarkTheme = colorMode === 'dark';
   return (
     <div>
       <div className={styles.appsContainer}>

--- a/src/pages/home/_components/TechnologiesGrid.jsx
+++ b/src/pages/home/_components/TechnologiesGrid.jsx
@@ -4,7 +4,8 @@ import clsx from 'clsx';
 import styles from './TechnologiesGrid.module.scss';
 
 export default function TechnologiesGrid({ list }) {
-  const { isDarkTheme } = useColorMode();
+  const { colorMode } = useColorMode();
+  const isDarkTheme = colorMode === 'dark';
   return (
     <div className={styles.techContainer}>
       {list.map((item) => (


### PR DESCRIPTION
This API will be removed in a future release of Docusaurus (ref https://github.com/facebook/docusaurus/pull/6930)