### PR TITLE
docs: add electron 20 blog post

### DIFF
--- a/blog/electron-20.md
+++ b/blog/electron-20.md
@@ -1,0 +1,64 @@
+---
+title: Electron 19.0.0
+date: 2022-05-24T00:00:00.000Z
+authors:
+    - name: VerteDinde
+      url: 'https://github.com/VerteDinde'
+      image_url: 'https://github.com/VerteDinde.png?size=96'
+    - name: ckerr
+      url: 'https://github.com/ckerr'
+      image_url: 'https://github.com/ckerr.png?size=96'
+slug: electron-19-0
+
+---
+
+Electron 19.0.0 has been released! It includes upgrades to Chromium `102`, V8 `10.2`, and Node.js `16.14.2`. Read below for more details!
+
+---
+
+The Electron team is excited to announce the release of Electron 19.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://www.electronjs.org/releases/stable). Continue reading for details about this release and please share any feedback you have!
+
+## Notable Changes
+
+### Electron Release Cadence Change
+
+The project is returning to its earlier policy of supporting the latest three major versions. [See our versioning document](https://www.electronjs.org/docs/latest/tutorial/electron-versioning) for more detailed information about Electron versioning and support. This had temporarily been four major versions to help users adjust to the new release cadence that began in Electron 15. You can read the [full details here](https://www.electronjs.org/blog/8-week-cadence). 
+
+### Stack Changes
+
+* Chromium `102`
+    * [New in Chrome 102](https://developer.chrome.com/blog/new-in-chrome-102/)
+    * [New in Chrome 101](https://developer.chrome.com/blog/new-in-chrome-101/)
+* Node.js `16.14.2`
+    * [Node 16.14.2 blog post](https://nodejs.org/en/blog/release/v16.14.2/)
+* V8 `10.2`
+
+## Breaking & API Changes
+
+Below are breaking changes introduced in Electron 19. More information about these and future changes can be found on the [Planned Breaking Changes](https://www.electronjs.org/docs/latest/breaking-changes) page.
+
+### Unsupported on Linux: `.skipTaskbar`
+
+The BrowserWindow constructor option `skipTaskbar` is no longer supported on Linux. Changed in [#33226](https://github.com/electron/electron/pull/33226)
+
+### Removed WebPreferences.preloadURL
+
+The semi-documented `preloadURL` property has been removed from WebPreferences. [#33228](https://github.com/electron/electron/pull/33228). `WebPreferences.preload` should be used instead.
+
+## End of Support for 15.x.y and 16.x.y
+
+Electron 14.x.y and 15.x.y have both reached end-of-support. This [returns](https://www.electronjs.org/blog/8-week-cadence/#-will-electron-extend-the-number-of-supported-versions) Electron to its [existing policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy) of supporting the latest three major versions. Developers and applications are encouraged to upgrade to a newer version of Electron.
+
+|	E15 (Sep'21) |	E16 (Nov'21) |	E17 (Feb'22) |	E18 (Mar'22) |	E19 (May'22) |
+| ---- | ---- | ---- | ---- | ---- |
+|	15.x.y |	16.x.y |	17.x.y |	18.x.y |	19.x.y |
+|	14.x.y |	15.x.y |	16.x.y |	17.x.y |	18.x.y |
+|	13.x.y |	14.x.y |	15.x.y |	16.x.y |	17.x.y |
+|	12.x.y |	13.x.y |	14.x.y |	15.x.y |	-- |
+## What's Next
+
+In the short term, you can expect the team to continue to focus on keeping up with the development of the major components that make up Electron, including Chromium, Node, and V8. Although we are careful not to make promises about release dates, our plan is to release new major versions of Electron with new versions of those components approximately every 2 months.
+
+You can find [Electron's public timeline here](https://www.electronjs.org/docs/latest/tutorial/electron-timelines).
+
+More information about future changes can be found on the [Planned Breaking Changes](https://github.com/electron/electron/blob/main/docs/breaking-changes.md) page.

--- a/blog/electron-20.md
+++ b/blog/electron-20.md
@@ -22,6 +22,8 @@ The Electron team is excited to announce the release of Electron 20.0.0! You can
 * Added immersive dark mode on Windows. [#34549](https://github.com/electron/electron/pull/34549)
 * Added support for panel-like behavior. Window can float over full-screened apps. [#34665](https://github.com/electron/electron/pull/34665)
 * Updated Windows Control Overlay buttons to look and feel more native on Windows 11. [#34888](https://github.com/electron/electron/pull/34888)
+* Renderers are now sandboxed by default unless `nodeIntegration: true` or `sandbox: false` is specified. [#35125](https://github.com/electron/electron/pull/35125)
+* Added safeguards when building native modules with nan. [#35160](https://github.com/electron/electron/pull/35160)
 
 ### Stack Changes
 

--- a/blog/electron-20.md
+++ b/blog/electron-20.md
@@ -39,7 +39,7 @@ Below are breaking changes introduced in Electron 20. More information about the
 
 ### V8 Memory Cage Enabled
 
-Electron 20 enables [V8 sandboxed pointers](https://docs.google.com/document/d/1HSap8-J3HcrZvT7-5NsbYWcjfc0BVoops5TDHZNsnko/edit), following Chrome's [decision to do the same in Chrome 103](https://chromiumdash.appspot.com/commit/9a6a76bf13d3ca1c6788de193afc5513919dd0ed). This has some implications for native modules. This feature has performance and security benefits, but also places some new restrictions on native modules, e.g. use of ArrayBuffers that point to external ("off-heap") memory. Please see [this blog post FIXME: Jeremy's blog post](https://electronjs.org/FIXME) for more information.
+Electron 20 enables [V8 sandboxed pointers](https://docs.google.com/document/d/1HSap8-J3HcrZvT7-5NsbYWcjfc0BVoops5TDHZNsnko/edit), following Chrome's [decision to do the same in Chrome 103](https://chromiumdash.appspot.com/commit/9a6a76bf13d3ca1c6788de193afc5513919dd0ed). This has some implications for native modules. This feature has performance and security benefits, but also places some new restrictions on native modules, e.g. use of ArrayBuffers that point to external ("off-heap") memory. Please see [this blog post](https://electronjs.org/blog/v8-memory-cage) for more information.
 
 ### Default Changed: renderers without `nodeIntegration: true` are sandboxed by default
 

--- a/blog/electron-20.md
+++ b/blog/electron-20.md
@@ -5,7 +5,7 @@ authors:
     - name: ckerr
       url: 'https://github.com/ckerr'
       image_url: 'https://github.com/ckerr.png?size=96'
-slug: electron-19-0
+slug: electron-20-0
 
 ---
 

--- a/blog/electron-20.md
+++ b/blog/electron-20.md
@@ -49,6 +49,14 @@ Previously, renderers that specified a preload script defaulted to being unsandb
 
 If your preload scripts do not depend on Node, no action is needed. If your preload scripts do depend on Node, either refactor them to remove Node usage from the renderer, or explicitly specify `sandbox: false` for the relevant renderers.
 
+### Fixed: spontaneous crashing in nan native modules
+
+In Electron 20, we changed two items related to native modules:
+1. V8 headers now use `c++17` by default. This flag was added to electron-rebuild.
+1. We fixed an issue where a missing include would cause spontaneous crashing in native modules that depended on nan.
+
+For the most stability, we recommend using node-gyp >=8.4.0 and electron-rebuild >=3.2.9 when rebuilding native modules, particularly modules that depend on nan. See electron [#35160](https://github.com/electron/electron/pull/35160) and node-gyp [#2497](https://github.com/nodejs/node-gyp/pull/2497) for more information.
+
 ### Removed: `.skipTaskbar` on Linux
 
 On X11, `skipTaskbar` sends a `_NET_WM_STATE_SKIP_TASKBAR` message to the X11 window manager. There is not a direct equivalent for Wayland, and the known workarounds have unacceptable tradeoffs (e.g. Window.is_skip_taskbar in GNOME requires unsafe mode), so Electron is unable to support this feature on Linux.

--- a/blog/electron-20.md
+++ b/blog/electron-20.md
@@ -20,6 +20,12 @@ The Electron team is excited to announce the release of Electron 20.0.0! You can
 
 ## Notable Changes
 
+### New Features
+
+* Added immersive dark mode on Windows. [#34549](https://github.com/electron/electron/pull/34549)
+* Added support for panel-like behavior. Window can float over full-screened apps. [#34665](https://github.com/electron/electron/pull/34665)
+* Updated Windows Control Overlay buttons to look and feel more native on Windows 11. [#34888](https://github.com/electron/electron/pull/34888)
+
 ### Stack Changes
 
 * Chromium `104`

--- a/blog/electron-20.md
+++ b/blog/electron-20.md
@@ -1,6 +1,6 @@
 ---
-title: Electron 19.0.0
-date: 2022-05-24T00:00:00.000Z
+title: Electron 20.0.0
+date: 2022-08-02:00:00.000Z
 authors:
     - name: VerteDinde
       url: 'https://github.com/VerteDinde'
@@ -45,16 +45,17 @@ The BrowserWindow constructor option `skipTaskbar` is no longer supported on Lin
 
 The semi-documented `preloadURL` property has been removed from WebPreferences. [#33228](https://github.com/electron/electron/pull/33228). `WebPreferences.preload` should be used instead.
 
-## End of Support for 15.x.y and 16.x.y
+## End of Support for 17.x.y
 
-Electron 14.x.y and 15.x.y have both reached end-of-support. This [returns](https://www.electronjs.org/blog/8-week-cadence/#-will-electron-extend-the-number-of-supported-versions) Electron to its [existing policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy) of supporting the latest three major versions. Developers and applications are encouraged to upgrade to a newer version of Electron.
+Electron 17.x.y has reached end-of-support as per the project's [support policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy). Developers and applications are encouraged to upgrade to a newer version of Electron.
 
-|	E15 (Sep'21) |	E16 (Nov'21) |	E17 (Feb'22) |	E18 (Mar'22) |	E19 (May'22) |
-| ---- | ---- | ---- | ---- | ---- |
-|	15.x.y |	16.x.y |	17.x.y |	18.x.y |	19.x.y |
-|	14.x.y |	15.x.y |	16.x.y |	17.x.y |	18.x.y |
-|	13.x.y |	14.x.y |	15.x.y |	16.x.y |	17.x.y |
-|	12.x.y |	13.x.y |	14.x.y |	15.x.y |	-- |
+| E18 (Mar'22) | E19 (May'22) | E20 (Aug'22) | E21 (Sep'22) | E22 (Dec'22) |
+| ------------ | ------------ | ------------ | ------------ | ------------ |
+| 18.x.y       | 19.x.y       | 20.x.y       | 21.x.y       | 22.x.y       |
+| 17.x.y       | 18.x.y       | 19.x.y       | 20.x.y       | 21.x.y       |
+| 16.x.y       | 17.x.y       | 18.x.y       | 19.x.y       | 20.x.y       |
+| 15.x.y       | --           | --           | --           | --           |
+
 ## What's Next
 
 In the short term, you can expect the team to continue to focus on keeping up with the development of the major components that make up Electron, including Chromium, Node, and V8. Although we are careful not to make promises about release dates, our plan is to release new major versions of Electron with new versions of those components approximately every 2 months.

--- a/blog/electron-20.md
+++ b/blog/electron-20.md
@@ -26,12 +26,13 @@ The project is returning to its earlier policy of supporting the latest three ma
 
 ### Stack Changes
 
-* Chromium `102`
-    * [New in Chrome 102](https://developer.chrome.com/blog/new-in-chrome-102/)
-    * [New in Chrome 101](https://developer.chrome.com/blog/new-in-chrome-101/)
-* Node.js `16.14.2`
-    * [Node 16.14.2 blog post](https://nodejs.org/en/blog/release/v16.14.2/)
-* V8 `10.2`
+* Chromium `104`
+    * [New in Chrome 104](https://developer.chrome.com/blog/new-in-chrome-104/)
+    * [New in Chrome 103](https://developer.chrome.com/blog/new-in-chrome-103/)
+    * [New in DevTools](https://developer.chrome.com/blog/new-in-devtools-104/)
+* Node.js `16.15.0`
+    * [Node 16.15.0 blog post](https://nodejs.org/en/blog/release/v16.15.0/)
+* V8 `10.4`
 
 ## Breaking & API Changes
 

--- a/blog/electron-20.md
+++ b/blog/electron-20.md
@@ -32,15 +32,17 @@ The Electron team is excited to announce the release of Electron 20.0.0! You can
 
 ## Breaking & API Changes
 
-Below are breaking changes introduced in Electron 19. More information about these and future changes can be found on the [Planned Breaking Changes](https://www.electronjs.org/docs/latest/breaking-changes) page.
+Below are breaking changes introduced in Electron 20. More information about these and future changes can be found on the [Planned Breaking Changes](https://www.electronjs.org/docs/latest/breaking-changes) page.
 
-### Unsupported on Linux: `.skipTaskbar`
+### Default Changed: renderers without `nodeIntegration: true` are sandboxed by default
 
-The BrowserWindow constructor option `skipTaskbar` is no longer supported on Linux. Changed in [#33226](https://github.com/electron/electron/pull/33226)
+Previously, renderers that specified a preload script defaulted to being unsandboxed. This meant that by default, preload scripts had access to Node.js. In Electron 20, this default has changed. Beginning in Electron 20, renderers will be sandboxed by default, unless `nodeIntegration: true` or `sandbox: false` is specified.
 
-### Removed WebPreferences.preloadURL
+If your preload scripts do not depend on Node, no action is needed. If your preload scripts do depend on Node, either refactor them to remove Node usage from the renderer, or explicitly specify `sandbox: false` for the relevant renderers.
 
-The semi-documented `preloadURL` property has been removed from WebPreferences. [#33228](https://github.com/electron/electron/pull/33228). `WebPreferences.preload` should be used instead.
+### Removed: `.skipTaskbar` on Linux
+
+On X11, `skipTaskbar` sends a `_NET_WM_STATE_SKIP_TASKBAR` message to the X11 window manager. There is not a direct equivalent for Wayland, and the known workarounds have unacceptable tradeoffs (e.g. Window.is_skip_taskbar in GNOME requires unsafe mode), so Electron is unable to support this feature on Linux.
 
 ## End of Support for 17.x.y
 

--- a/blog/electron-20.md
+++ b/blog/electron-20.md
@@ -12,17 +12,13 @@ slug: electron-19-0
 
 ---
 
-Electron 19.0.0 has been released! It includes upgrades to Chromium `102`, V8 `10.2`, and Node.js `16.14.2`. Read below for more details!
+Electron 20.0.0 has been released! It includes upgrades to Chromium `104`, V8 `10.4`, and Node.js `16.15.0`. Read below for more details!
 
 ---
 
-The Electron team is excited to announce the release of Electron 19.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://www.electronjs.org/releases/stable). Continue reading for details about this release and please share any feedback you have!
+The Electron team is excited to announce the release of Electron 20.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://www.electronjs.org/releases/stable). Continue reading for details about this release and please share any feedback you have!
 
 ## Notable Changes
-
-### Electron Release Cadence Change
-
-The project is returning to its earlier policy of supporting the latest three major versions. [See our versioning document](https://www.electronjs.org/docs/latest/tutorial/electron-versioning) for more detailed information about Electron versioning and support. This had temporarily been four major versions to help users adjust to the new release cadence that began in Electron 15. You can read the [full details here](https://www.electronjs.org/blog/8-week-cadence). 
 
 ### Stack Changes
 

--- a/blog/electron-20.md
+++ b/blog/electron-20.md
@@ -2,9 +2,6 @@
 title: Electron 20.0.0
 date: 2022-08-02:00:00.000Z
 authors:
-    - name: VerteDinde
-      url: 'https://github.com/VerteDinde'
-      image_url: 'https://github.com/VerteDinde.png?size=96'
     - name: ckerr
       url: 'https://github.com/ckerr'
       image_url: 'https://github.com/ckerr.png?size=96'
@@ -39,6 +36,10 @@ The Electron team is excited to announce the release of Electron 20.0.0! You can
 ## Breaking & API Changes
 
 Below are breaking changes introduced in Electron 20. More information about these and future changes can be found on the [Planned Breaking Changes](https://www.electronjs.org/docs/latest/breaking-changes) page.
+
+### V8 Memory Cage Enabled
+
+Electron 20 enables [V8 sandboxed pointers](https://docs.google.com/document/d/1HSap8-J3HcrZvT7-5NsbYWcjfc0BVoops5TDHZNsnko/edit), following Chrome's [decision to do the same in Chrome 103](https://chromiumdash.appspot.com/commit/9a6a76bf13d3ca1c6788de193afc5513919dd0ed). This has some implications for native modules. This feature has performance and security benefits, but also places some new restrictions on native modules, e.g. use of ArrayBuffers that point to external ("off-heap") memory. Please see [this blog post FIXME: Jeremy's blog post](https://electronjs.org/FIXME) for more information.
 
 ### Default Changed: renderers without `nodeIntegration: true` are sandboxed by default
 


### PR DESCRIPTION
The 20.0.0 blog post.

CC @electron/wg-releases 