### PR TITLE
Fix broken link to examples in tutorial 4

### DIFF
--- a/docs/latest/tutorial/tutorial-4-adding-features.md
+++ b/docs/latest/tutorial/tutorial-4-adding-features.md
@@ -64,7 +64,7 @@ into end users' hands.
 
 [discord]: https://discord.com/invite/APGC3k5yaH
 [github]: https://github.com/electron/electronjs.org-new/issues/new
-[how to]: latest/tutorial/examples.md
+[how-to]: latest/tutorial/examples.md
 [node-platform]: https://nodejs.org/api/process.html#process_process_platform
 
 <!-- Tutorial links -->


### PR DESCRIPTION
The link currently displays as follows (see [here](https://www.electronjs.org/docs/latest/tutorial/tutorial-adding-features#how-to-examples)):

    To get started, check out the [How-To Examples][how-to] doc.