### PR TITLE
chore: Revert "Fix broken link to examples in tutorial 4"

### DIFF
--- a/docs/latest/tutorial/tutorial-4-adding-features.md
+++ b/docs/latest/tutorial/tutorial-4-adding-features.md
@@ -64,7 +64,7 @@ into end users' hands.
 
 [discord]: https://discord.com/invite/APGC3k5yaH
 [github]: https://github.com/electron/electronjs.org-new/issues/new
-[how-to]: latest/tutorial/examples.md
+[how to]: latest/tutorial/examples.md
 [node-platform]: https://nodejs.org/api/process.html#process_process_platform
 
 <!-- Tutorial links -->


### PR DESCRIPTION
This reverts commit 21325bee69f1d18df46390d48a39827a3b12f3b5.

This should be amended upstream in `electron/electron` rather than in this repo since future updates will overwrite this change.

cc @molant 