### PR TITLE
fix: rectify the hyperlink pointing to electron forge

### DIFF
--- a/src/pages/fiddle/index.jsx
+++ b/src/pages/fiddle/index.jsx
@@ -226,7 +226,8 @@ export default function FiddlePage() {
             <p>
               Fiddle can automatically turn your experiment into binaries you
               can share with your friends, coworkers, or grandparents. It does
-              so thanks to <a href="electronforge.io">Electron Forge</a>,
+              so thanks to{' '}
+              <a href="https://www.electronforge.io/">Electron Forge</a>,
               allowing you to package your fiddle as an app for Windows, macOS,
               or Linux.
             </p>


### PR DESCRIPTION
The [hyperlink incorrectly points](https://github.com/electron/electronjs.org-new/blob/main/src/pages/fiddle/index.jsx#L229) to electron forge, leading to a 404 (https://www.electronjs.org/electronforge.io) - 

<img width="660" alt="Screenshot 2022-08-09 at 11 06 39 PM" src="https://user-images.githubusercontent.com/53977614/183721970-f906d199-ef77-4c31-867b-6df4bd4c4fe6.png">


<strong>Note:</strong> This change is not tested (but I assume it to be correct!) since I am unable to build the website locally. It always get stuck at 46% while building the markdown - 

<img width="919" alt="Screenshot 2022-08-09 at 10 58 43 PM" src="https://user-images.githubusercontent.com/53977614/183722644-530d06a4-61cd-49f9-876d-eb7e459ac7b5.png">


Any ideas?

