### PR TITLE
chore: Electron 21 blog post

### DIFF
--- a/blog/electron-20-0.md
+++ b/blog/electron-20-0.md
@@ -39,10 +39,6 @@ The Electron team is excited to announce the release of Electron 20.0.0! You can
 
 Below are breaking changes introduced in Electron 20. More information about these and future changes can be found on the [Planned Breaking Changes](https://www.electronjs.org/docs/latest/breaking-changes) page.
 
-### V8 Memory Cage Enabled
-
-Electron 20 enables [V8 sandboxed pointers](https://docs.google.com/document/d/1HSap8-J3HcrZvT7-5NsbYWcjfc0BVoops5TDHZNsnko/edit), following Chrome's [decision to do the same in Chrome 103](https://chromiumdash.appspot.com/commit/9a6a76bf13d3ca1c6788de193afc5513919dd0ed). This has some implications for native modules. This feature has performance and security benefits, but also places some new restrictions on native modules, e.g. use of ArrayBuffers that point to external ("off-heap") memory. Please see [this blog post](https://electronjs.org/blog/v8-memory-cage) for more information.
-
 ### Default Changed: renderers without `nodeIntegration: true` are sandboxed by default
 
 Previously, renderers that specified a preload script defaulted to being unsandboxed. This meant that by default, preload scripts had access to Node.js. In Electron 20, this default has changed. Beginning in Electron 20, renderers will be sandboxed by default, unless `nodeIntegration: true` or `sandbox: false` is specified.

--- a/blog/electron-21-0.md
+++ b/blog/electron-21-0.md
@@ -38,19 +38,20 @@ If you have any feedback, please share it with us on Twitter, or join our commun
 * Chromium `106`
     * [New in Chrome 106](https://developer.chrome.com/blog/new-in-chrome-106/)
     * [New in Chrome 105](https://developer.chrome.com/blog/new-in-chrome-105/)
-    * [New in DevTools](https://developer.chrome.com/blog/new-in-devtools-106/)
+    * [New in DevTools 106](https://developer.chrome.com/blog/new-in-devtools-106/)
+    * [New in DevTools 105](https://developer.chrome.com/blog/new-in-devtools-105/)
 * Node.js `16.16.0`
     * [Node 16.16.0 blog post](https://nodejs.org/en/blog/release/v16.16.0/)
 * V8 `10.4`
 
-## Breaking Changes
+## Breaking & API Changes
+
+Below are breaking changes introduced in Electron 21. 
 
 * Enabled the V8 memory cage for external buffers. See https://www.electronjs.org/blog/v8-memory-cage for more details. [#34724](https://github.com/electron/electron/pull/34724) 
 * Refactored `webContents.printToPDF` to align with the Chrome Devtools implementation. [#33654](https://github.com/electron/electron/pull/33654) 
 
-## API Changes
-
-Below are breaking changes introduced in Electron 21. More information about these and future changes can be found on the [Planned Breaking Changes](https://www.electronjs.org/docs/latest/breaking-changes) page.
+More information about these and future changes can be found on the [Planned Breaking Changes](https://www.electronjs.org/docs/latest/breaking-changes) page.
 
 ## End of Support for 18.x.y
 
@@ -64,7 +65,7 @@ Electron 18.x.y has reached end-of-support as per the project's [support policy]
 
 ## What's Next
 
-In the short term, you can expect the team to continue to focus on keeping up with the development of the major components that make up Electron, including Chromium, Node, and V8. Although we are careful not to make promises about release dates, our plan is to release new major versions of Electron with new versions of those components approximately every 2 months.
+In the short term, you can expect the team to continue to focus on keeping up with the development of the major components that make up Electron, including Chromium, Node, and V8.
 
 You can find [Electron's public timeline here](https://www.electronjs.org/docs/latest/tutorial/electron-timelines).
 

--- a/blog/electron-21-0.md
+++ b/blog/electron-21-0.md
@@ -1,0 +1,61 @@
+---
+title: Electron 21.0.0
+date: 2022-09-27T00:00:00.000Z
+authors:
+    - name: ckerr
+      url: 'https://github.com/ckerr'
+      image_url: 'https://github.com/ckerr.png?size=96'
+    - name: vertedinde
+      url: 'https://github.com/vertedinde'
+      image_url: 'https://github.com/vertedinde.png?size=96'
+    - name: georgexu99
+      url: 'https://github.com/georgexu99'
+      image_url: 'https://github.com/georgexu99.png?size=96'
+slug: electron-21-0
+
+---
+
+Electron 20.0.0 has been released! It includes upgrades to Chromium `106`, V8 `10.4`, and Node.js `16.16.0`. Read below for more details!
+
+---
+
+The Electron team is excited to announce the release of Electron 21.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://www.electronjs.org/releases/stable). Continue reading for details about this release and please share any feedback you have!
+
+## Notable Changes
+
+### New Features
+
+TODO: Add features here
+
+### Stack Changes
+
+* Chromium `106`
+    * [New in Chrome 106](https://developer.chrome.com/blog/new-in-chrome-106/)
+    * [New in Chrome 105](https://developer.chrome.com/blog/new-in-chrome-105/)
+    * [New in DevTools](https://developer.chrome.com/blog/new-in-devtools-106/)
+* Node.js `16.16.0`
+    * [Node 16.16.0 blog post](https://nodejs.org/en/blog/release/v16.16.0/)
+* V8 `10.4`
+
+## Breaking & API Changes
+
+Below are breaking changes introduced in Electron 21. More information about these and future changes can be found on the [Planned Breaking Changes](https://www.electronjs.org/docs/latest/breaking-changes) page.
+
+
+## End of Support for 18.x.y
+
+Electron 18.x.y has reached end-of-support as per the project's [support policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy). Developers and applications are encouraged to upgrade to a newer version of Electron.
+
+| E18 (Mar'22) | E19 (May'22) | E20 (Aug'22) | E21 (Sep'22) | E22 (Dec'22) |
+| ------------ | ------------ | ------------ | ------------ | ------------ |
+| 18.x.y       | 19.x.y       | 20.x.y       | 21.x.y       | 22.x.y       |
+| 17.x.y       | 18.x.y       | 19.x.y       | 20.x.y       | 21.x.y       |
+| 16.x.y       | 17.x.y       | 18.x.y       | 19.x.y       | 20.x.y       |
+
+## What's Next
+
+In the short term, you can expect the team to continue to focus on keeping up with the development of the major components that make up Electron, including Chromium, Node, and V8. Although we are careful not to make promises about release dates, our plan is to release new major versions of Electron with new versions of those components approximately every 2 months.
+
+You can find [Electron's public timeline here](https://www.electronjs.org/docs/latest/tutorial/electron-timelines).
+
+More information about future changes can be found on the [Planned Breaking Changes](https://github.com/electron/electron/blob/main/docs/breaking-changes.md) page.

--- a/blog/electron-21-0.md
+++ b/blog/electron-21-0.md
@@ -49,7 +49,7 @@ Below are breaking changes introduced in Electron 21.
 
 ### V8 Memory Cage Enabled
 
-Electron 20 enables [V8 sandboxed pointers](https://docs.google.com/document/d/1HSap8-J3HcrZvT7-5NsbYWcjfc0BVoops5TDHZNsnko/edit), following Chrome's [decision to do the same in Chrome 103](https://chromiumdash.appspot.com/commit/9a6a76bf13d3ca1c6788de193afc5513919dd0ed). This has some implications for native modules. This feature has performance and security benefits, but also places some new restrictions on native modules, e.g. use of ArrayBuffers that point to external ("off-heap") memory. Please see [this blog post](https://electronjs.org/blog/v8-memory-cage) for more information. [#34724](https://github.com/electron/electron/pull/34724) 
+Electron 21 enables [V8 sandboxed pointers](https://docs.google.com/document/d/1HSap8-J3HcrZvT7-5NsbYWcjfc0BVoops5TDHZNsnko/edit), following Chrome's [decision to do the same in Chrome 103](https://chromiumdash.appspot.com/commit/9a6a76bf13d3ca1c6788de193afc5513919dd0ed). This has some implications for native modules. This feature has performance and security benefits, but also places some new restrictions on native modules, e.g. use of ArrayBuffers that point to external ("off-heap") memory. Please see [this blog post](https://electronjs.org/blog/v8-memory-cage) for more information. [#34724](https://github.com/electron/electron/pull/34724) 
 
 ### Refactored webContents.printToPDF
 Refactored `webContents.printToPDF` to align with Chromium's headless implementation. See [#33654](https://github.com/electron/electron/pull/33654) for more information.

--- a/blog/electron-21-0.md
+++ b/blog/electron-21-0.md
@@ -19,7 +19,9 @@ Electron 21.0.0 has been released! It includes upgrades to Chromium `106`, V8 `1
 
 ---
 
-The Electron team is excited to announce the release of Electron 21.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://www.electronjs.org/releases/stable). Continue reading for details about this release and please share any feedback you have!
+The Electron team is excited to announce the release of Electron 21.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://www.electronjs.org/releases/stable). Continue reading for details about this release.
+
+If you have any feedback, please share it with us on Twitter, or join our community [Discord](https://discord.com/invite/electronjs)! Bugs and feature requests can be reported in Electron's [issue tracker](https://github.com/electron/electron/issues).
 
 ## Notable Changes
 

--- a/blog/electron-21-0.md
+++ b/blog/electron-21-0.md
@@ -38,18 +38,21 @@ If you have any feedback, please share it with us on Twitter, or join our commun
 
 ### New Features
 
-* Added `webFrameMain.origin`. [#35534](https://github.com/electron/electron/pull/35534) <span style="font-size:small;">(Also in [19](https://github.com/electron/electron/pull/35624), [20](https://github.com/electron/electron/pull/35535))</span>
-* Added immersive dark mode on Windows. [#33624](https://github.com/electron/electron/pull/33624) <span style="font-size:small;">(Also in [20](https://github.com/electron/electron/pull/34549))</span>
+* Added `webFrameMain.origin`. [#35534](https://github.com/electron/electron/pull/35534)
 * Added new `WebContents.ipc` and `WebFrameMain.ipc` APIs. [#35231](https://github.com/electron/electron/pull/35231) 
-* Added support for panel-like behavior. Window can float over full-screened apps. [#34388](https://github.com/electron/electron/pull/34388) <span style="font-size:small;">(Also in [20](https://github.com/electron/electron/pull/34665))</span>
+* Added support for panel-like behavior. Window can float over full-screened apps. [#34388](https://github.com/electron/electron/pull/34388)
 * Added support for push notifications from APNs for macOS apps. [#33574](https://github.com/electron/electron/pull/33574) 
 
 ## Breaking & API Changes
 
 Below are breaking changes introduced in Electron 21. 
 
-* Enabled the V8 memory cage for external buffers. See https://www.electronjs.org/blog/v8-memory-cage for more details. [#34724](https://github.com/electron/electron/pull/34724) 
-* Refactored `webContents.printToPDF` to align with the Chrome Devtools implementation. [#33654](https://github.com/electron/electron/pull/33654) 
+### V8 Memory Cage Enabled
+
+Electron 20 enables [V8 sandboxed pointers](https://docs.google.com/document/d/1HSap8-J3HcrZvT7-5NsbYWcjfc0BVoops5TDHZNsnko/edit), following Chrome's [decision to do the same in Chrome 103](https://chromiumdash.appspot.com/commit/9a6a76bf13d3ca1c6788de193afc5513919dd0ed). This has some implications for native modules. This feature has performance and security benefits, but also places some new restrictions on native modules, e.g. use of ArrayBuffers that point to external ("off-heap") memory. Please see [this blog post](https://electronjs.org/blog/v8-memory-cage) for more information. [#34724](https://github.com/electron/electron/pull/34724) 
+
+### Refactored webContents.printToPDF
+Refactored `webContents.printToPDF` to align with Chromium's headless implementation. See [#33654](https://github.com/electron/electron/pull/33654) for more information.
 
 More information about these and future changes can be found on the [Planned Breaking Changes](https://www.electronjs.org/docs/latest/breaking-changes) page.
 

--- a/blog/electron-21-0.md
+++ b/blog/electron-21-0.md
@@ -15,7 +15,7 @@ slug: electron-21-0
 
 ---
 
-Electron 20.0.0 has been released! It includes upgrades to Chromium `106`, V8 `10.4`, and Node.js `16.16.0`. Read below for more details!
+Electron 21.0.0 has been released! It includes upgrades to Chromium `106`, V8 `10.4`, and Node.js `16.16.0`. Read below for more details!
 
 ---
 

--- a/blog/electron-21-0.md
+++ b/blog/electron-21-0.md
@@ -19,7 +19,7 @@ Electron 21.0.0 has been released! It includes upgrades to Chromium `106`, V8 `1
 
 ---
 
-The Electron team is excited to announce the release of Electron 21.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://www.electronjs.org/releases/stable). Continue reading for details about this release.
+The Electron team is excited to announce the release of Electron 21.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://releases.electronjs.org/releases/stable). Continue reading for details about this release.
 
 If you have any feedback, please share it with us on Twitter, or join our community [Discord](https://discord.com/invite/electronjs)! Bugs and feature requests can be reported in Electron's [issue tracker](https://github.com/electron/electron/issues).
 

--- a/blog/electron-21-0.md
+++ b/blog/electron-21-0.md
@@ -34,7 +34,7 @@ If you have any feedback, please share it with us on Twitter, or join our commun
     * [New in DevTools 105](https://developer.chrome.com/blog/new-in-devtools-105/)
 * Node.js `16.16.0`
     * [Node 16.16.0 blog post](https://nodejs.org/en/blog/release/v16.16.0/)
-* V8 `10.4`
+* V8 `10.6`
 
 ### New Features
 

--- a/blog/electron-21-0.md
+++ b/blog/electron-21-0.md
@@ -15,7 +15,7 @@ slug: electron-21-0
 
 ---
 
-Electron 21.0.0 has been released! It includes upgrades to Chromium `106`, V8 `10.4`, and Node.js `16.16.0`. Read below for more details!
+Electron 21.0.0 has been released! It includes upgrades to Chromium `106`, V8 `10.6`, and Node.js `16.16.0`. Read below for more details!
 
 ---
 

--- a/blog/electron-21-0.md
+++ b/blog/electron-21-0.md
@@ -25,14 +25,6 @@ If you have any feedback, please share it with us on Twitter, or join our commun
 
 ## Notable Changes
 
-### New Features
-
-* Added `webFrameMain.origin`. [#35534](https://github.com/electron/electron/pull/35534) <span style="font-size:small;">(Also in [19](https://github.com/electron/electron/pull/35624), [20](https://github.com/electron/electron/pull/35535))</span>
-* Added immersive dark mode on Windows. [#33624](https://github.com/electron/electron/pull/33624) <span style="font-size:small;">(Also in [20](https://github.com/electron/electron/pull/34549))</span>
-* Added new `WebContents.ipc` and `WebFrameMain.ipc` APIs. [#35231](https://github.com/electron/electron/pull/35231) 
-* Added support for panel-like behavior. Window can float over full-screened apps. [#34388](https://github.com/electron/electron/pull/34388) <span style="font-size:small;">(Also in [20](https://github.com/electron/electron/pull/34665))</span>
-* Added support for push notifications from APNs for macOS apps. [#33574](https://github.com/electron/electron/pull/33574) 
-
 ### Stack Changes
 
 * Chromium `106`
@@ -43,6 +35,14 @@ If you have any feedback, please share it with us on Twitter, or join our commun
 * Node.js `16.16.0`
     * [Node 16.16.0 blog post](https://nodejs.org/en/blog/release/v16.16.0/)
 * V8 `10.4`
+
+### New Features
+
+* Added `webFrameMain.origin`. [#35534](https://github.com/electron/electron/pull/35534) <span style="font-size:small;">(Also in [19](https://github.com/electron/electron/pull/35624), [20](https://github.com/electron/electron/pull/35535))</span>
+* Added immersive dark mode on Windows. [#33624](https://github.com/electron/electron/pull/33624) <span style="font-size:small;">(Also in [20](https://github.com/electron/electron/pull/34549))</span>
+* Added new `WebContents.ipc` and `WebFrameMain.ipc` APIs. [#35231](https://github.com/electron/electron/pull/35231) 
+* Added support for panel-like behavior. Window can float over full-screened apps. [#34388](https://github.com/electron/electron/pull/34388) <span style="font-size:small;">(Also in [20](https://github.com/electron/electron/pull/34665))</span>
+* Added support for push notifications from APNs for macOS apps. [#33574](https://github.com/electron/electron/pull/33574) 
 
 ## Breaking & API Changes
 

--- a/blog/v8-memory-cage.md
+++ b/blog/v8-memory-cage.md
@@ -8,11 +8,11 @@ authors:
 slug: v8-memory-cage
 ---
 
-Electron 20 and later will have the V8 Memory Cage enabled, with implications for some native modules.
+Electron 21 and later will have the V8 Memory Cage enabled, with implications for some native modules.
 
 ---
 
-In Electron 20, we will be enabling [V8 sandboxed pointers](https://docs.google.com/document/d/1HSap8-J3HcrZvT7-5NsbYWcjfc0BVoops5TDHZNsnko/edit) in Electron, following Chrome's [decision to do the same in Chrome 103](https://chromiumdash.appspot.com/commit/9a6a76bf13d3ca1c6788de193afc5513919dd0ed). This has some implications for native modules. Also, we previously enabled a related technology, [pointer compression](https://v8.dev/blog/pointer-compression), in Electron 14. We didn't talk about it much then, but pointer compression has implications for the maximum V8 heap size.
+In Electron 21, we will be enabling [V8 sandboxed pointers](https://docs.google.com/document/d/1HSap8-J3HcrZvT7-5NsbYWcjfc0BVoops5TDHZNsnko/edit) in Electron, following Chrome's [decision to do the same in Chrome 103](https://chromiumdash.appspot.com/commit/9a6a76bf13d3ca1c6788de193afc5513919dd0ed). This has some implications for native modules. Also, we previously enabled a related technology, [pointer compression](https://v8.dev/blog/pointer-compression), in Electron 14. We didn't talk about it much then, but pointer compression has implications for the maximum V8 heap size.
 
 These two technologies, when enabled, are significantly beneficial for security, performance and memory usage. However, there are some downsides to enabling them, too.
 


### PR DESCRIPTION
Electron 17 blog post
@electron/wg-releases , @ckerr , @georgexu99

Please add a comment for items you think we should highlight in the blog post.

Merge target: Sept 27th, after 21.0.0 releases successfully

⚠️ Do not merge until the following are completed ⚠️

- [x]  update node, v8 and chromium versions from final chrome roll under Stack Changes section
- [x]  add a couple new features in tag line sentence
- [ ]  make sure link for M106 "New In Chrome" blog post is live
- [x]  add a few bullets for Highlight Features section
- [x]  add any missing items in Breaking Changes section
- [x]  add items for API Changes and/or Deprecated APIs section