### PR TITLE
chore: delete extra tutorial section in sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -245,13 +245,6 @@ module.exports = {
         'latest/tutorial/asar-archives',
       ],
     },
-    {
-      type: 'category',
-      label: 'Tutorial',
-      items: [
-        'latest/tutorial/forge-overview',
-      ],
-    },
   ],
   api: [
     {


### PR DESCRIPTION
title