### PR TITLE
fix: update Forge's banner link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,7 @@ module.exports = {
   themeConfig: {
     announcementBar: {
       id: 'announcementBar',
-      content: `Introducing Electron Forge 6, a complete pipeline for building your Electron apps. Read more in the <strong><a target="_blank" rel="noopener noreferrer" href="./blog/">Forge 6 announcement blog</a></strong>!`,
+      content: `Introducing Electron Forge 6, a complete pipeline for building your Electron apps. Read more in the <strong><a target="_blank" rel="noopener noreferrer" href="https://www.electronjs.org/blog/forge-v6-release">Forge 6 announcement blog</a></strong>!`,
       backgroundColor: '#A2ECFB',
       isCloseable: true,
     },


### PR DESCRIPTION
Fixes the banner link for Forge's blog post (it's currently 404'ing because it tries to redirect based on whatever page you're on at the time - e.g. `electronjs.org/docs/blog` instead of just `electronjs.org/blog`)