### PR TITLE
fix(api-structures): support reference-style links

### DIFF
--- a/src/components/APIStructurePreview.module.scss
+++ b/src/components/APIStructurePreview.module.scss
@@ -15,6 +15,7 @@
     border: 1px solid var(--tooltip-color);
     border-radius: 20px;
     width: 1.6em;
+    max-height: 55%; // this value should be (1 / line-height) of .markdown p (see custom.scss)
     font-size: 50%;
     text-align: center;
     position: absolute;

--- a/src/transformers/api-structure-previews.js
+++ b/src/transformers/api-structure-previews.js
@@ -2,35 +2,61 @@ const visitParents = require('unist-util-visit-parents');
 const fs = require('fs');
 const path = require('path');
 
-/**
- *
- *
- */
-
 module.exports = function attacher() {
   return transformer;
 };
+
+let structureDefinitions;
+let hasStructures;
+
 /**
  *
  * @param {import("unist").Parent} tree
  */
 async function transformer(tree) {
-  visitParents(tree, isStructure, visitor);
-  tree.children.unshift({
-    type: 'import',
-    value:
-      "import APIStructurePreview from '@site/src/components/APIStructurePreview';",
-  });
+  structureDefinitions = new Map();
+  hasStructures = false;
+  visitParents(tree, checkLinksandDefinitions, replaceLinkWithPreview);
+  visitParents(tree, isStructureLinkReference, replaceLinkWithPreview);
+  if (hasStructures) {
+    tree.children.unshift({
+      type: 'import',
+      value:
+        "import APIStructurePreview from '@site/src/components/APIStructurePreview';",
+    });
+  }
 }
 
 /**
+ * This function is the test function for the first pass of the tree visitor.
+ * Any values returning 'true' will run replaceLinkWithPreview().
+ *
+ * As a side effect, this function also puts all reference-style links (definitions)
+ * for API structures into a Map, which will be used on the second pass.
+ * @param {import("unist").Node} node
+ * @returns
+ */
+function checkLinksandDefinitions(node, _index, _parent) {
+  if (
+    node?.type === 'definition' &&
+    typeof node.url === 'string' &&
+    node.url.includes('/api/structures/')
+  ) {
+    structureDefinitions.set(node.identifier, node.url);
+  }
+  return node.type === 'link' && node?.url.includes('/api/structures/');
+}
+
+/**
+ * This function is the test function from the second pass of the tree visitor.
+ * Any values returning 'true' will run replaceLinkWithPreview().
  *
  * @param {import("unist").Node} node
  * @returns
  */
-function isStructure(node, _index, _parent) {
+function isStructureLinkReference(node, _index, _parent) {
   return (
-    node.type === 'link' && node.url.startsWith('/docs/latest/api/structures/')
+    node.type === 'linkReference' && structureDefinitions.has(node?.identifier)
   );
 }
 
@@ -38,9 +64,13 @@ function isStructure(node, _index, _parent) {
  *
  * @param {import("unist").Node} node
  */
-function visitor(node, _ancestors) {
+function replaceLinkWithPreview(node, _ancestors) {
+  // depending on if the node is a direct link or a reference-style link,
+  // we get its URL differently.
+  const preview =
+    node.type === 'link' ? node.url : structureDefinitions.get(node.identifier);
   const file = fs.readFileSync(
-    path.join(__dirname, '..', '..', `${node.url}.md`)
+    path.join(__dirname, '..', '..', `${preview}.md`)
   );
   // hack to remove frontmatter from docs.
   const str = file
@@ -55,7 +85,8 @@ function visitor(node, _ancestors) {
   // replace the raw link file with our JSX component.
   // See src/components/APIStructurePreview.jsx for implementation.
   if (Array.isArray(node.children) && node.children.length > 0) {
+    hasStructures = true;
     node.type = 'jsx';
-    node.value = `<APIStructurePreview url="${node.url}" title="${node.children[0].value}" content="${str}"/>`;
+    node.value = `<APIStructurePreview url="${preview}" title="${node.children[0].value}" content="${str}"/>`;
   }
 }


### PR DESCRIPTION
Fixes #295 

Adds a second pass to the AST walker to find and replace reference-style links. These were previously skipped in the visitor check since we only checked for `link`-type nodes.

For more information on Node types for the Markdown AST, see the [mdast spec](https://github.com/syntax-tree/mdast).

```md

[Example link][1]

[1]: https://example.com

```