### PR TITLE
style: fix webpack warning for `end` property.

### DIFF
--- a/src/pages/apps/apps.module.scss
+++ b/src/pages/apps/apps.module.scss
@@ -128,7 +128,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: end;
+  justify-content: flex-end;
   flex-wrap: wrap;
   gap: 10px;
 }


### PR DESCRIPTION
When running `yarn start` on the website repo, the build runs but with the following warning emitted from webpack:

```
<w> [webpack.cache.PackFileCacheStrategy] Skipped not serializable cache item 'Compilation/modules|/Users/erick.zhao/Developer/electron/electronjs.org-new/node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[11].oneOf[0].use[1]!/Users/erick.zhao/Developer/electron/electronjs.org-new/node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[11].oneOf[0].use[2]!/Users/erick.zhao/Developer/electron/electronjs.org-new/node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[11].oneOf[0].use[3]!/Users/erick.zhao/Developer/electron/electronjs.org-new/src/pages/apps/apps.module.scss': No serializer registered for Warning
<w> while serializing webpack/lib/cache/PackFileCacheStrategy.PackContentItems -> webpack/lib/NormalModule -> Array { 1 items } -> webpack/lib/ModuleWarning -> Warning
```

From the advice given in https://github.com/webpack/webpack/issues/12458#issuecomment-763713922, I added some logging statements into webpack.

```
ModuleWarning [Warning: Warning

(136:3) autoprefixer: end value has mixed support, consider using flex-end instead] undefined
```


Turns out autoprefixer didn't like our usage of `justify-content: end` in `apps.module.scss`, which apparently isn't supported on Safari.