### PR TITLE
fix(css): remove `backdrop-filter` prop from navbar styles

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -105,8 +105,6 @@
 }
 
 .navbar {
-  backdrop-filter: blur(12px);
-
   &--dark {
     --ifm-navbar-background-color: var(--electron-color-dark);
     --ifm-navbar-link-color: var(--electron-color-light);


### PR DESCRIPTION
Fixes #301

The mobile menu was broken here!