### PR TITLE
chore: remove hard-coded url from navbar link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,9 +46,6 @@ module.exports = {
       logo: {
         alt: 'Electron homepage',
         src: 'assets/img/logo.svg',
-        // TODO: This can be removed when the SPA root homepage is working
-        href: 'https://electronjs.org',
-        target: '_self',
       },
       items: [
         {


### PR DESCRIPTION
Since we landed the Docusaurus-based homepage, we can now remove the hard-coded link to https://electronjs.org set up in our navbar logo.

