### PR TITLE
feat: add `ko` locale

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -25,7 +25,7 @@ const config: Config = {
   themes: ['@docusaurus/theme-mermaid'],
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'de', 'es', 'fr', 'ja', 'pt', 'ru', 'zh'],
+    locales: ['en', 'de', 'es', 'fr', 'ja', 'ko', 'pt', 'ru', 'zh'],
     path: 'i18n',
     localeConfigs: {},
   },


### PR DESCRIPTION
Resolves electron/electron#43131.
Needs update on [Target Languages on Crowdin](https://support.crowdin.com/changing-target-languages/#managing-target-languages).

![image](https://github.com/user-attachments/assets/a0ac8840-ea25-4d5f-a3f4-baf9d4ea664d)