### PR TITLE
build: try bumping API structure content timeout

### DIFF
--- a/src/transformers/api-structure-previews.ts
+++ b/src/transformers/api-structure-previews.ts
@@ -131,7 +131,7 @@ async function transformer(tree: Parent, file: VFile) {
             `Timed out waiting for API structure content from ${relativeStructurePath}`,
           ),
         );
-      }, 60_000);
+      }, 120_000);
 
       const promise = new Promise<Parent>((resolve_, reject_) => {
         resolve = (value: Parent) => {


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

The build has started consistently timing out waiting for API structure content, it might be related to #834, maybe builds are a little slower after the bump? Lets try putting in a higher timeout to see if that's the issue.

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
