### PR TITLE
ci: use another GitHub app to approve automated update PRs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -20,8 +20,6 @@ jobs:
     environment: docs-updater
     env:
       SHA: ${{ github.event.client_payload.sha || github.event.inputs.sha }}
-    permissions:
-      pull-requests: write
     steps:
       - name: Generate GitHub App token (updater app)
         uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

The original approach in #868 of using the default GitHub actions app to approve PRs turned out to be untenable as it would require changing a setting at the enterprise level which we don't want to have to deal with. So use a dedicated GitHub app instead.

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
