### PR TITLE
docs: add Electron 39 blog post

### DIFF
--- a/blog/electron-39-0.md
+++ b/blog/electron-39-0.md
@@ -25,7 +25,7 @@ If you have any feedback, please share it with us on [Bluesky](https://bsky.app/
 - Node `22.20.0`
   - [v22.20.0 Announcement](https://nodejs.org/en/blog/release/v22.20.0)
   - [v22.19.0 Announcement](https://nodejs.org/en/blog/release/v22.19.0)
-- V8 `14.0`
+- V8 `14.2`
   - [V8 roll increment](https://chromium.googlesource.com/v8/v8.git/+/bb294624702efbb17691b642333f06bf5108e600)
 
 Electron 39 upgrades Chromium from `140.0.7339.41` to `142.0.7444.52`, Node.js from `22.18.0` to `v22.20.0`, and V8 from `14.0` to `14.2`.


### PR DESCRIPTION
This PR adds the blog post for Electron 39. @electron/wg-releases, @electron/wg-outreach

Merge target: Oct 28, after 39.0.0 releases.

⚠️ Do not merge until the following are completed ⚠️ 

* [x]   Update node, v8 and chromium versions from final chrome roll under Stack Changes section
* [x]   Edit link for M142 "New In Chrome" blog post
* [x]   Add a few bullets for New Features section
* [x]   Add any missing items in Breaking Changes section
* [x]   Update End of Support

_Note: The "Check Blog links" job is going to fail until the Chrome 142 announcement blog comes out. A fail is expected until about Tuesday_

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
