### PR TITLE
ci: tweak automated docs PR merging

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -71,5 +71,5 @@ jobs:
         run: |
           set -eo pipefail
           gh pr review "docs/update-to-${SHA}" --approve
-          gh pr checks "docs/update-to-${SHA}" --watch
+          gh pr checks "docs/update-to-${SHA}" --watch --fail-fast
           gh pr merge "docs/update-to-${SHA}" --squash


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

`gh pr merge --auto` is not working and it's a pain to debug why that is. Switch to watching the PR for checks to finish (and failing if they fail), then merge without the `--auto` flag.

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
