### PR TITLE
ci: add a quick sleep before checking status of automated PR

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -71,5 +71,6 @@ jobs:
         run: |
           set -eo pipefail
           gh pr review "docs/update-to-${SHA}" --approve
+          sleep 30  # Checks don't always start immediately
           gh pr checks "docs/update-to-${SHA}" --watch --fail-fast
           gh pr merge "docs/update-to-${SHA}" --squash


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

Last run of the automated update failed to merge because "no checks reported on the 'docs/update-to-32f97529fcecf70aad21a728940c751da5c54323' branch", so I think it was too fast in checking.

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
