### PR TITLE
fix: fix how to report security issues in blog posts

### DIFF
--- a/blog/chromium-rce-vulnerability.md
+++ b/blog/chromium-rce-vulnerability.md
@@ -22,8 +22,9 @@ npm i electron@latest --save-dev
 To learn more about best practices for keeping your Electron apps secure,
 see our [security tutorial].
 
-Please contact security@electronjs.org if you wish to report a vulnerability in
-Electron.
+Please file a [GitHub Security Advisory] if you wish to report a vulnerability
+in Electron.
 
 [sandbox option]: https://electronjs.org/docs/api/sandbox-option
 [security tutorial]: https://electronjs.org/docs/tutorial/security
+[GitHub Security Advisory]: https://github.com/electron/electron/security

--- a/blog/cve-2019-13720.md
+++ b/blog/cve-2019-13720.md
@@ -34,7 +34,9 @@ This vulnerability was discovered by Anton Ivanov and Alexey Kulaev at Kaspersky
 
 To learn more about best practices for keeping your Electron apps secure, see our [security tutorial].
 
-If you wish to report a vulnerability in Electron, email security@electronjs.org.
+Please file a [GitHub Security Advisory] if you wish to report a vulnerability
+in Electron.
 
 [security tutorial]: https://electronjs.org/docs/tutorial/security
 [announcement]: https://chromereleases.googleblog.com/2019/10/stable-channel-update-for-desktop_31.html
+[GitHub Security Advisory]: https://github.com/electron/electron/security

--- a/blog/filereader-fix.md
+++ b/blog/filereader-fix.md
@@ -39,6 +39,8 @@ This vulnerability was discovered by Clement Lecigne of Google's Threat Analysis
 
 To learn more about best practices for keeping your Electron apps secure, see our [security tutorial].
 
-If you wish to report a vulnerability in Electron, email security@electronjs.org.
+Please file a [GitHub Security Advisory] if you wish to report a vulnerability
+in Electron.
 
 [security tutorial]: https://electronjs.org/docs/tutorial/security
+[GitHub Security Advisory]: https://github.com/electron/electron/security

--- a/blog/magellan-fix.md
+++ b/blog/magellan-fix.md
@@ -33,6 +33,8 @@ This vulnerability was discovered by the Tencent Blade team, who have published 
 
 To learn more about best practices for keeping your Electron apps secure, see our [security tutorial].
 
-If you wish to report a vulnerability in Electron, email security@electronjs.org.
+Please file a [GitHub Security Advisory] if you wish to report a vulnerability
+in Electron.
 
 [security tutorial]: https://electronjs.org/docs/tutorial/security
+[GitHub Security Advisory]: https://github.com/electron/electron/security

--- a/blog/protocol-handler-fix.md
+++ b/blog/protocol-handler-fix.md
@@ -51,9 +51,10 @@ See the [app.setAsDefaultProtocolClient] API for more details.
 To learn more about best practices for keeping your Electron apps secure,
 see our [security tutorial].
 
-If you wish to report a vulnerability in Electron, email
-security@electronjs.org.
+Please file a [GitHub Security Advisory] if you wish to report a vulnerability
+in Electron.
 
 [security tutorial]: https://electronjs.org/docs/tutorial/security
 [app.setasdefaultprotocolclient]: https://electronjs.org/docs/api/app#appsetasdefaultprotocolclientprotocol-path-args-macos-windows
 [cve-2018-1000006]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000006
+[GitHub Security Advisory]: https://github.com/electron/electron/security

--- a/blog/web-preferences-fix.md
+++ b/blog/web-preferences-fix.md
@@ -68,7 +68,9 @@ This vulnerability was found and reported responsibly to the Electron project by
 
 To learn more about best practices for keeping your Electron apps secure, see our [security tutorial].
 
-If you wish to report a vulnerability in Electron, email security@electronjs.org.
+Please file a [GitHub Security Advisory] if you wish to report a vulnerability
+in Electron.
 
 [security tutorial]: https://electronjs.org/docs/tutorial/security
 [cve-2018-15685]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15685
+[GitHub Security Advisory]: https://github.com/electron/electron/security

--- a/blog/webview-fix.md
+++ b/blog/webview-fix.md
@@ -58,6 +58,9 @@ This vulnerability was found and reported responsibly to the Electron project by
 
 To learn more about best practices for keeping your Electron apps secure, see our [security tutorial](https://electronjs.org/docs/tutorial/security).
 
-To report a vulnerability in Electron, please email security@electronjs.org.
+Please file a [GitHub Security Advisory] if you wish to report a vulnerability
+in Electron.
 
 Please join our [email list](https://groups.google.com/forum/#!forum/electronjs) to receive updates about releases and security updates.
+
+[GitHub Security Advisory]: https://github.com/electron/electron/security

--- a/blog/window-open-fix.md
+++ b/blog/window-open-fix.md
@@ -34,6 +34,8 @@ This vulnerability was found and reported responsibly to the Electron project by
 
 To learn more about best practices for keeping your Electron apps secure, see our [security tutorial].
 
-If you wish to report a vulnerability in Electron, email security@electronjs.org.
+Please file a [GitHub Security Advisory] if you wish to report a vulnerability
+in Electron.
 
 [security tutorial]: https://electronjs.org/docs/tutorial/security
+[GitHub Security Advisory]: https://github.com/electron/electron/security


### PR DESCRIPTION
#### Description of Change

GHSA should be preferred over the email according to @MarshallOfSound.

See https://electronhq.slack.com/archives/C3ANJ97H6/p1761782304643429?thread_ts=1761741484.257889&cid=C3ANJ97H6

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
