### PR TITLE
style(showcase): use blurred logo instead of generated highlight colour

### DIFF
--- a/src/plugins/apps/components/AppCard.module.scss
+++ b/src/plugins/apps/components/AppCard.module.scss
@@ -25,11 +25,25 @@
   padding: 2rem 0;
   border-top-left-radius: var(--ifm-card-border-radius);
   border-top-right-radius: var(--ifm-card-border-radius);
+  position: relative;
+  overflow: hidden;
+}
+
+.appLogoBlurred {
+  position: absolute;
+  width: auto;
+  height: 96px;
+  transform: scale(3);
+  filter: blur(30px);
+  opacity: 0.5;
+  z-index: 0;
 }
 
 .appLogo {
   width: auto;
   height: 96px;
+  position: relative;
+  z-index: 1;
 }
 
 .appCard {

--- a/src/plugins/apps/components/AppCard.tsx
+++ b/src/plugins/apps/components/AppCard.tsx
@@ -4,13 +4,15 @@ import { App } from '..';
 
 import styles from './AppCard.module.scss';
 
-type AppCardProps = Omit<App, 'date' | 'faintColorOnWhite' | 'slug'>;
+type AppCardProps = Omit<
+  App,
+  'date' | 'faintColorOnWhite' | 'slug' | 'highlightColor'
+>;
 
 export default function AppCard({
   name,
   description,
   category,
-  highlightColor,
   logo,
   isFavorite,
   website,
@@ -25,10 +27,13 @@ export default function AppCard({
       )}
     >
       <div className={styles.forceLight}>
-        <div
-          className={styles.appLogoContainer}
-          style={{ background: highlightColor }}
-        >
+        <div className={styles.appLogoContainer}>
+          <img
+            className={styles.appLogoBlurred}
+            src={logo}
+            alt=""
+            aria-hidden="true"
+          />
           <img className={styles.appLogo} src={logo} alt="" loading="lazy" />
         </div>
       </div>

--- a/src/plugins/apps/components/apps.module.scss
+++ b/src/plugins/apps/components/apps.module.scss
@@ -44,7 +44,7 @@
 }
 
 .filterBadge {
-  margin-left: 0.2rem;
+  margin-left: 0.4rem;
   padding: 0.2rem 0.4rem;
   font-size: 80%;
   background-color: var(--ifm-color-emphasis-200);

--- a/src/plugins/apps/components/index.tsx
+++ b/src/plugins/apps/components/index.tsx
@@ -193,7 +193,6 @@ export default function AppsPage({ apps, categories }: AppsPluginContent) {
                     name={app.name}
                     description={app.description}
                     category={app.category}
-                    highlightColor={app.faintColorOnWhite}
                     logo={`https://raw.githubusercontent.com/erickzhao/apps/master/apps/${app.slug}/${app.slug}-icon-128.png`}
                     isFavorite={true}
                     website={app.website}
@@ -223,7 +222,6 @@ export default function AppsPage({ apps, categories }: AppsPluginContent) {
                   name={app.name}
                   description={app.description}
                   category={app.category}
-                  highlightColor={app.faintColorOnWhite}
                   logo={`https://raw.githubusercontent.com/erickzhao/apps/master/apps/${app.slug}/${app.slug}-icon-128.png`}
                   isFavorite={app.isFavorite}
                   website={app.website}


### PR DESCRIPTION
The main impetus for this change is that https://github.com/electron/apps has a lot of dependencies that simply generate a colour to be used for the background of the app's entry in the showcase page.

We used to use this colour more extensively in an older iteration of the website, but it's simpler (and prettier) to just make this background a blurred image on the fly:

<img width="1549" height="1023" alt="image" src="https://github.com/user-attachments/assets/c8d6b331-9ee5-4ceb-81b4-38b7107590a5" />
