### PR TITLE
fix(electron/website): Replaced the broken Angular logo with OFFICIAL png Link.

### DIFF
--- a/src/pages/home/_index.tsx
+++ b/src/pages/home/_index.tsx
@@ -254,7 +254,7 @@ export default function Home() {
                 {
                   name: 'Angular',
                   image:
-                    'https://upload.wikimedia.org/wikipedia/commons/c/cf/Angular_full_color_logo.svg',
+                    'https://angular.io/assets/images/logos/angular/angular.png',
                 },
                 {
                   name: 'TypeScript',


### PR DESCRIPTION
## Problem:
The SVG link for the Angular logo [(from upload.wikimedia.org)](https://upload.wikimedia.org/wikipedia/commons/c/cf/Angular_full_color_logo.svg) is not loading, resulting in a broken image on the page as reported in #918 . (As shown in the image Below!!:)

<p align="center">
    <img width="700" height="700" alt="image" src="https://github.com/user-attachments/assets/4ec3e115-b6db-4169-9cce-72b3c4b0df16" />
</p>


# Solution:
### I've replaced the problematic Wikimedia SVG link with a direct link to the **official .png logo asset hosted on [angular.io](https://angular.io/assets/images/logos/angular/angular.png)**.

> This resolves the error and ensures the correct, modern Angular logo is displayed.

# Screenshot:
<p align="center">
    <img width="500" height="550" alt="image" src="https://github.com/user-attachments/assets/6b99504f-d82b-4741-b9ff-6de7b514b078" />
</p>
😄
