### PR TITLE
ci: don't fail docs audit if .sha is newer non-docs commit on e/e

### DIFF
--- a/.github/workflows/audit-docs-version.yml
+++ b/.github/workflows/audit-docs-version.yml
@@ -69,13 +69,13 @@ jobs:
               if (comparison.status !== 200) {
                 throw new Error('Failed to compare commits');
               }
-        
+
               if (comparison.data.behind_by === 0 && comparison.data.ahead_by >= 0) {
                 core.summary.addRaw('🎉 Docs are up-to-date');
               } else {
                 console.log(`Got ${latestDocsSHA}, expected ${commit.sha}`);
                 core.summary.addRaw('🚨 Docs are NOT up-to-date');
-  
+
                 // Set this as failed so it's easy to scan runs to find failures
                 process.exitCode = 1;
               }


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

Sometimes `docs/latest/.sha` gets out ahead of what we would expect it to be since `electron-website-updater` is supposed to only send any changes to `docs/` on `e/e` (to minimize churn here), but has a bug where it'll send commits that touch any file with the word `docs` in the name. When that happens we can end up ahead of the expected SHA from `e/e`, so be more lenient and as long as we're equal to or ahead of the expected SHA, consider that as pass.

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
