### PR TITLE
fix: remove typo in 404 error page

### DIFF
--- a/src/theme/NotFound.jsx
+++ b/src/theme/NotFound.jsx
@@ -33,7 +33,7 @@ export default function NotFound() {
                   id="theme.NotFound.p1"
                   description="The first paragraph of the 404 page"
                 >
-                  We could not find what you were looking for. Erick.
+                  We could not find what you were looking for.
                 </Translate>
               </p>
               <p>


### PR DESCRIPTION
#### Description of Change

In NotFound.jsx contributor named erick added their name in line 36.
Fixed this unethical practice :)


#### Checklist

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)

<img width="1470" height="1001" alt="Screenshot 2025-12-02 at 10 27 01" src="https://github.com/user-attachments/assets/8d800963-e410-4a62-ab6d-16995e0e89d7" />


