### PR TITLE
fix: replaces wrong image address in apps page

### DIFF
--- a/src/plugins/apps/components/index.tsx
+++ b/src/plugins/apps/components/index.tsx
@@ -222,7 +222,7 @@ export default function AppsPage({ apps, categories }: AppsPluginContent) {
                   name={app.name}
                   description={app.description}
                   category={app.category}
-                  logo={`https://raw.githubusercontent.com/electron/apps/main/${app.slug}/${app.slug}-icon-128.png`}
+                  logo={`https://raw.githubusercontent.com/electron/apps/main/apps/${app.slug}/${app.slug}-icon-128.png`}
                   isFavorite={app.isFavorite}
                   website={app.website}
                   repository={app.repository}


### PR DESCRIPTION
#### Description of Change

When visiting [electronjs.org/apps](https://www.electronjs.org/apps/). I saw that image icons were broken for non-favorites apps. 
After inspecting, I found that image links was wrong. 

#### Checklist

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
