### PR TITLE
feat: transform non-docs relative links to GitHub content links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -15,6 +15,7 @@ import apiOptionsClass from './src/transformers/api-options-class';
 import apiStructurePreviews from './src/transformers/api-structure-previews';
 import jsCodeBlocks from './src/transformers/js-code-blocks';
 import fiddleEmbedder from './src/transformers/fiddle-embedder';
+import githubContentsLinks from './src/transformers/github-content-links';
 import apiHistory from './src/transformers/api-history';
 
 let docsSHA = undefined;
@@ -287,6 +288,7 @@ const config: Config = {
             apiStructurePreviews,
             jsCodeBlocks,
             fiddleEmbedder,
+            githubContentsLinks,
             apiHistory,
             [npm2yarn, { sync: true, converters: ['yarn'] }],
           ],

--- a/src/transformers/github-content-links.ts
+++ b/src/transformers/github-content-links.ts
@@ -1,0 +1,65 @@
+import path from 'node:path';
+
+import { visitParents } from 'unist-util-visit-parents';
+import { Node, Parent } from 'unist';
+import type { Definition, Link } from 'mdast';
+import type { VFile } from 'vfile';
+import { latestElectronVersion } from '../util/latest-electron-version';
+import { isDefinition, isLink } from '../util/mdx-utils';
+
+const DOCS_FOLDER = path.join(__dirname, '..', '..', 'docs', 'latest');
+const RELATIVE_LINK_REGEX = /^(?:\.\.?\/)+(\S+)$/;
+
+let _version = '';
+async function getVersion() {
+  if (_version === '') {
+    _version = await latestElectronVersion();
+  }
+
+  return _version;
+}
+
+/**
+ * `attacher` runs once for the entire plugin's lifetime.
+ */
+export default function attacher() {
+  return transformer;
+}
+
+/**
+ * The `transformer` function scope is instantiated once per file
+ * processed by this MDX plugin.
+ */
+async function transformer(tree: Parent, vfile: VFile) {
+  const version = await getVersion();
+
+  const findRelativeLinksOutsideDocs = (node: Node) => {
+    if (
+      (isLink(node) || isDefinition(node)) &&
+      (node.url.startsWith('./') || node.url.startsWith('../'))
+    ) {
+      // Check if the path resolves outside to be outside of the doc folder
+      const relativePath = path.relative(DOCS_FOLDER, vfile.dirname);
+      const resolvedPath = path.join(relativePath, node.url);
+
+      return resolvedPath.startsWith('../');
+    }
+
+    return false;
+  };
+
+  const nodes: Set<Definition | Link> = new Set();
+
+  visitParents(
+    tree,
+    findRelativeLinksOutsideDocs,
+    (node: Definition | Link) => {
+      nodes.add(node);
+    },
+  );
+
+  for (const node of nodes) {
+    // Strip off the leading relative path segments
+    node.url = `https://github.com/electron/electron/blob/v${version}/${node.url.match(RELATIVE_LINK_REGEX)[1]}`;
+  }
+}


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

Closes #977.

It seems like by the time the transformer runs, all relative links that resolve to a file within `docs/latest` have already been turned into absolute paths starting with `docs/latest`, so really we could just transform any link that starts with `../`. To be safe though (in case that implicit behavior changes in the future), this PR does an additional check to confirm the relative path resolves to being outside of the `docs` directory before it transforms it into a GitHub link.

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
