### PR TITLE
docs: add Electron 40 blog post

### DIFF
--- a/blog/electron-40-0.md
+++ b/blog/electron-40-0.md
@@ -7,7 +7,7 @@ slug: electron-40-0
 tags: [release]
 ---
 
-Electron 40.0.0 has been released! It includes upgrades to Chromium 144.0.7559.31, V8 14.4, and Node 24.11.1.
+Electron 40.0.0 has been released! It includes upgrades to Chromium 144.0.7559.60, V8 14.4, and Node 24.11.1.
 
 ---
 


### PR DESCRIPTION
This PR adds the blog post for Electron 40. @electron/wg-releases, @electron/wg-outreach

Merge target: Jan 13, after 40.0.0 releases.

⚠️ Do not merge until the following are completed ⚠️

- [x]  Update node, v8 and chromium versions from final chrome roll under Stack Changes section
- [x]  Edit link for M144 "New In Chrome" blog post
- [x]  Add a few bullets for New Features section
- [x]  Add any missing items in Breaking Changes section
- [x]  Update End of Support

_Note: The "Check Blog links" job is going to fail until the Chrome 144 announcement blog comes out. A fail is expected until about Tuesday_

**Checklist**
- [x] -  This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)