### PR TITLE
ci: update docs version audit to work off releases

### DIFF
--- a/.github/workflows/audit-docs-version.yml
+++ b/.github/workflows/audit-docs-version.yml
@@ -48,7 +48,7 @@ jobs:
             const { data: commit } = await github.rest.repos.getCommit({
               owner: 'electron',
               repo: 'electron',
-              ref: `tags/v${versions.latestStable.version}`,
+              ref: `refs/tags/v${versions.latestStable.version}`,
             });
 
             const delta = Date.now() - new Date(publishedAt).getTime();


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

In support of electron/electron#49429, which will switch the website to only updating on releases rather than any commit which touches `docs/`.

I'm leaving in the changes from #941 to allow for the commit to be a newer one on that branch, so that we leave ourselves the option of deploying between releases if there's a doc change we want to put up right away, without failing this audit. That also means this change should be backwards compatible and could be merged before electron/electron#49429.

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
