### PR TITLE
ci: update docs/latest/.sha even if no docs changes

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -44,19 +44,14 @@ jobs:
           git add .
           if [ "$(git status --porcelain | grep -v 'docs/latest/.sha')" = "" ]; then
             echo "::warning:: Unexpectedly found no new content for docs - this might be a bug"
-            echo "changes=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changes=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Push changes to branch
-        if: ${{ steps.prebuild.outputs.changes == 'true' }}
         uses: dsanders11/github-app-commit-action@43de6da2f4d927e997c0784c7a0b61bd19ad6aac # v1.5.0
         with:
           message: 'chore: update ref to docs (🤖)'
           ref: 'docs/update-to-${{ env.SHA }}'
           token: ${{ steps.generate-token.outputs.token }}
       - name: Create pull request
-        if: ${{ steps.prebuild.outputs.changes == 'true' }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
@@ -67,11 +62,9 @@ jobs:
             --head "docs/update-to-${SHA}" \
             --base main
       - name: Get GitHub App token (approver app)
-        if: ${{ steps.prebuild.outputs.changes == 'true' }}
         id: secret-service
         uses: electron/secret-service-action@3476425e8b30555aac15b1b7096938e254b0e155 # v1.0.0
       - name: Approve and merge pull request
-        if: ${{ steps.prebuild.outputs.changes == 'true' }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ fromJSON(steps.secret-service.outputs.secrets || '{}').PR_APPROVER_GH_TOKEN }}


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

This partially reverts #993 so that we still bump `docs/latest/.sha` even if a given release had no docs changes. This is to keep the audit happy without creating unnecessary complexity of finding the latest release that included docs changes.

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
