### PR TITLE
feat: add Copy Page button to doc pages

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -17,6 +17,7 @@ import jsCodeBlocks from './src/transformers/js-code-blocks';
 import fiddleEmbedder from './src/transformers/fiddle-embedder';
 import githubContentsLinks from './src/transformers/github-content-links';
 import apiHistory from './src/transformers/api-history';
+import copyPageButton from './src/transformers/copy-page-button';
 
 let docsSHA = undefined;
 
@@ -302,6 +303,7 @@ const config: Config = {
             fiddleEmbedder,
             githubContentsLinks,
             apiHistory,
+            copyPageButton,
             [npm2yarn, { sync: true, converters: ['yarn'] }],
           ],
         },

--- a/src/components/CopyPageButton/icons.tsx
+++ b/src/components/CopyPageButton/icons.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+interface IconProps {
+  className?: string;
+}
+
+export const CopyIcon = ({ className }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    className={className}
+  >
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </svg>
+);
+
+export const CheckIcon = ({ className }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    className={className}
+  >
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);

--- a/src/components/CopyPageButton/index.tsx
+++ b/src/components/CopyPageButton/index.tsx
@@ -1,0 +1,89 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { CheckIcon, CopyIcon } from './icons';
+import styles from './styles.module.scss';
+
+interface CopyPageButtonProps {
+  /** Raw markdown source of the current page */
+  rawMarkdown: string;
+}
+
+const RESET_DELAY_MS = 2000;
+
+const CopyPageButton = ({ rawMarkdown }: CopyPageButtonProps) => {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    const writeWithFallback = () => {
+      const textarea = document.createElement('textarea');
+      textarea.value = rawMarkdown;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'fixed';
+      textarea.style.top = '0';
+      textarea.style.left = '0';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      try {
+        document.execCommand('copy');
+      } finally {
+        document.body.removeChild(textarea);
+      }
+    };
+
+    try {
+      if (
+        typeof navigator !== 'undefined' &&
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === 'function'
+      ) {
+        await navigator.clipboard.writeText(rawMarkdown);
+      } else {
+        writeWithFallback();
+      }
+    } catch {
+      writeWithFallback();
+    }
+
+    setCopied(true);
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => {
+      setCopied(false);
+      timeoutRef.current = null;
+    }, RESET_DELAY_MS);
+  }, [rawMarkdown]);
+
+  const buttonClassName = copied
+    ? `${styles.copyButton} ${styles.copied}`
+    : styles.copyButton;
+
+  return (
+    <div className={styles.wrapper}>
+      <button
+        type="button"
+        className={buttonClassName}
+        onClick={handleCopy}
+        aria-label="Copy page content to clipboard"
+      >
+        {copied ? <CheckIcon /> : <CopyIcon />}
+        <span>{copied ? 'Copied' : 'Copy Page'}</span>
+      </button>
+      <span aria-live="polite" className={styles.srOnly}>
+        {copied ? 'Page content copied to clipboard' : ''}
+      </span>
+    </div>
+  );
+};
+
+export default CopyPageButton;

--- a/src/components/CopyPageButton/styles.module.scss
+++ b/src/components/CopyPageButton/styles.module.scss
@@ -1,0 +1,76 @@
+.wrapper {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+.copyButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+
+  font-family: inherit;
+  font-size: 0.8rem;
+  font-weight: var(--ifm-font-weight-semibold);
+  line-height: 1.25;
+
+  color: var(--ifm-color-emphasis-800);
+  background-color: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-button-border-radius, 0.4rem);
+
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+
+  &:hover {
+    background-color: var(--ifm-color-emphasis-100);
+    border-color: var(--ifm-color-emphasis-400);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ifm-color-primary);
+    outline-offset: 2px;
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  :root[data-theme='dark'] & {
+    color: var(--ifm-color-emphasis-700);
+    background-color: var(--ifm-background-surface-color);
+    border-color: var(--ifm-color-emphasis-300);
+
+    &:hover {
+      background-color: var(--ifm-color-emphasis-200);
+      border-color: var(--ifm-color-emphasis-500);
+      color: var(--ifm-color-emphasis-900);
+    }
+  }
+}
+
+.copied {
+  color: var(--ifm-color-success);
+  border-color: var(--ifm-color-success);
+
+  &:hover {
+    color: var(--ifm-color-success);
+    border-color: var(--ifm-color-success);
+  }
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/transformers/copy-page-button.ts
+++ b/src/transformers/copy-page-button.ts
@@ -1,0 +1,66 @@
+/**
+ * Injects a `<CopyPageButton rawMarkdown="..." />` MDX node at the top of every
+ * doc page so visitors can copy the raw markdown source to their clipboard
+ * (mirroring the "Copy Page" pattern from shadcn/ui's docs).
+ *
+ * The raw markdown is read straight from `vfile.value`, which holds the
+ * unmodified source string for the file currently being compiled. The button
+ * then renders inside the article body via the same MDX-injection pattern used
+ * by `api-history.ts` for `<ApiHistoryTable />`.
+ */
+
+import type { Parent } from 'unist';
+import type { VFile } from 'vfile';
+
+import { getJSXImport, isImport } from '../util/mdx-utils';
+
+const COMPONENT_NAME = 'CopyPageButton';
+
+export default function attacher() {
+  return transformer;
+}
+
+function transformer(tree: Parent, vfile: VFile) {
+  const rawMarkdown =
+    typeof vfile.value === 'string'
+      ? vfile.value
+      : Buffer.isBuffer(vfile.value)
+        ? vfile.value.toString('utf-8')
+        : '';
+
+  if (!rawMarkdown) {
+    return;
+  }
+
+  const buttonNode = {
+    type: 'mdxJsxFlowElement',
+    name: COMPONENT_NAME,
+    attributes: [
+      {
+        type: 'mdxJsxAttribute',
+        name: 'rawMarkdown',
+        value: rawMarkdown,
+      },
+    ],
+    children: [],
+    data: {
+      _mdxExplicitJsx: true,
+    },
+  };
+
+  // Insert the button as the first body node so it renders just below the
+  // page title (Docusaurus renders the frontmatter title above the MDX body).
+  tree.children.unshift(buttonNode as unknown as Parent['children'][number]);
+
+  // Only add the import if no existing one references the component (e.g.
+  // a doc author manually imported it).
+  const alreadyImported = tree.children.some(
+    (child) =>
+      isImport(child) &&
+      child.value.includes(`@site/src/components/${COMPONENT_NAME}`),
+  );
+
+  if (!alreadyImported) {
+    tree.children.unshift(getJSXImport(COMPONENT_NAME));
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a **Copy Page** button to every documentation page, letting users copy the raw markdown source to their clipboard with one click
- Implements a remark transformer (`copy-page-button.ts`) that injects the raw markdown into each page at build time
- Creates a `CopyPageButton` component with clipboard API support and a fallback for older browsers
- Styled to match the existing site design, including dark mode

Inspired by the [shadcn/ui docs](https://ui.shadcn.com/docs/components/radix/alert) copy-page feature.

## Test plan

- [ ] Verify the button appears on doc pages (API refs, tutorials, guides)
- [ ] Click "Copy Page" and paste into a text editor — confirm raw markdown is copied
- [ ] Test in dark mode
- [ ] Test on mobile viewport
- [ ] Confirm no bundle size regression beyond the raw content payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)