### PR TITLE
ci: don't deploy to docs-updater environment

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -17,7 +17,9 @@ permissions: {}
 jobs:
   update-docs:
     runs-on: ubuntu-latest
-    environment: docs-updater
+    environment:
+      name: docs-updater
+      deployment: false
     permissions:
       id-token: write # for secret service access
     env:


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

We only use this for secret access.

Refs https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/#github-actions-now-allows-developers-to-use-environments-without-auto-deployment

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
