### PR TITLE
blog: fix heading levels in Electron 40 and 41 release blogs

### DIFF
--- a/blog/electron-40-0.md
+++ b/blog/electron-40-0.md
@@ -31,7 +31,7 @@ If you have any feedback, please share it with us on [Bluesky](https://bsky.app/
 
 Electron 40 upgrades Chromium from `142.0.7444.52` to `144.0.7559.60`, Node.js from `v22.20.0` to `v24.11.1`, and V8 from `14.2` to `14.4`.
 
-### New Features and Improvements
+## New Features and Improvements
 
 - Added `"memory-eviction"` as a possible reason for a child process to exit. [#48362](https://github.com/electron/electron/pull/48362)
 - Added `bypassCustomProtocolHandlers` option to `net.request`. [#48883](https://github.com/electron/electron/pull/48883) <sup>(Also in [38](https://github.com/electron/electron/pull/48881), [39](https://github.com/electron/electron/pull/48882))</sup>
@@ -40,13 +40,13 @@ Electron 40 upgrades Chromium from `142.0.7444.52` to `144.0.7559.60`, Node.js f
 - Enabled resetting accent color to follow system accent settings if a previous color has been set via `window.setAccentColor(null)`. [#48274](https://github.com/electron/electron/pull/48274) <sup>(Also in [38](https://github.com/electron/electron/pull/48853), [39](https://github.com/electron/electron/pull/48852))</sup>
 - Updated `nativeImage.createFromNamedImage` to support SF Symbol names. [#48772](https://github.com/electron/electron/pull/48772) <sup>(Also in [39](https://github.com/electron/electron/pull/48773))</sup>
 
-### Breaking Changes
+## Breaking Changes
 
-#### Deprecated: clipboard API access from renderer processes
+### Deprecated: clipboard API access from renderer processes
 
 Using the `clipboard` API directly in the renderer process is deprecated. If you want to call this API from a renderer process, place the API call in your preload script and expose it using the `contextBridge` API.
 
-#### Behavior Changed: macOS dSYM files now compressed with tar.xz
+### Behavior Changed: macOS dSYM files now compressed with tar.xz
 
 Debug symbols for macOS (dSYM) now use xz compression in order to handle larger file sizes. `dsym.zip` files are now `dsym.tar.xz` files. End users using debug symbols may need to update their zip utilities.
 

--- a/blog/electron-41-0.md
+++ b/blog/electron-41-0.md
@@ -86,15 +86,15 @@ Electron 41 upgrades Chromium from `144.0.7559.60` to `146.0.7680.65`, Node.js f
 - Enabled V8 trap handlers for WASM behind `WasmTrapHandlers` [fuse](https://www.electronjs.org/docs/latest/tutorial/fuses). [#49839](https://github.com/electron/electron/pull/49839)
 - Extended actions support for Windows notifications to include buttons, select dropdowns, and replies. [#49787](https://github.com/electron/electron/pull/49787) <sup>(Also in [40](https://github.com/electron/electron/pull/49786))</sup>
 
-### Breaking Changes
+## Breaking Changes
 
-#### Behavior Changed: PDFs no longer create a separate WebContents
+### Behavior Changed: PDFs no longer create a separate WebContents
 
 Previously, PDF resources created a separate guest [`WebContents`](https://www.electronjs.org/docs/latest/api/web-contents) for rendering. Now, PDFs are rendered within the same `WebContents` instead. If you have code to detect PDF resources, use the [frame tree](https://www.electronjs.org/docs/latest/api/web-frame-main) instead of `WebContents`.
 
 Under the hood, Chromium [enabled](https://chromium-review.googlesource.com/c/chromium/src/+/7239572) a feature that changes PDFs to use out-of-process iframes (OOPIFs) instead of the `MimeHandlerViewGuest` extension.
 
-#### Behavior Changed: Updated Cookie Change Cause in the Cookie `'changed'` Event
+### Behavior Changed: Updated Cookie Change Cause in the Cookie `'changed'` Event
 
 We have updated the cookie change cause in the cookie [`'changed'` event](https://www.electronjs.org/docs/latest/api/cookies#event-changed).
 When a new cookie is set, the change cause is `inserted`.
@@ -102,7 +102,7 @@ When a cookie is deleted, the change cause remains `explicit`.
 When the cookie being set is identical to an existing one (same name, domain, path, and value, with no actual changes), the change cause is `inserted-no-change-overwrite`.
 When the value of the cookie being set remains unchanged but some of its attributes are updated, such as the expiration attribute, the change cause will be `inserted-no-value-change-overwrite`.
 
-#### Deprecated: `showHiddenFiles` in Dialogs on Linux
+### Deprecated: `showHiddenFiles` in Dialogs on Linux
 
 This property will still be honored on macOS and Windows, but support on Linux
 will be removed in a future version of Electron. GTK intends for this to be a user choice rather


### PR DESCRIPTION
## Summary

Continues the cleanup started in #952, which standardized heading levels in release blog posts but only covered posts up through Electron 39. The Electron 40 and 41 posts have the same heading-level inconsistencies that #952 set out to fix.

### `blog/electron-40-0.md`
"New Features and Improvements" and "Breaking Changes" were nested under "Stack Changes" as `###` instead of being top-level peers. Promoted them to `##` and bumped their children from `####` to `###`.

### `blog/electron-41-0.md`
"Breaking Changes" was at `###` instead of `##`, with its children one level too deep at `####`. Promoted accordingly.

After this PR, the heading hierarchy in both posts matches the standard from #952:

```
## Notable Changes (where applicable)
   ### subsections
## Stack Changes
## New Features and Improvements
## Breaking Changes
   ### subsections
## End of Support
## What's Next
```

The Electron 42 post already follows this structure, so no changes were needed there.

## Test plan

- [x] Visually inspect rendered Electron 40 and 41 blog posts to confirm heading hierarchy renders correctly
- [x] Confirm no other content was modified

https://claude.ai/code/session_014rV49r1Rmk6mej76CWCK8e

---
_Generated by [Claude Code](https://claude.ai/code/session_014rV49r1Rmk6mej76CWCK8e)_