### PR TITLE
UI/UX: Unclosed <div> tag in fiddle template

### DIFF
--- a/create-electron-documentation/templates/fiddle/index.html
+++ b/create-electron-documentation/templates/fiddle/index.html
@@ -18,7 +18,7 @@
         <p id="answer"></p>
       </div>
 
-    <div>
+    </div>
 
     <script src="renderer.js"></script>
   </body>


### PR DESCRIPTION
## Summary

UI/UX: Unclosed <div> tag in fiddle template

## Problem

**Severity**: `High` | **File**: `create-electron-documentation/templates/fiddle/index.html:L17`

The outer <div> element at line 17 is never closed, leaving malformed HTML.

## Solution

Add </div> closing tag after line 21 (after the script tag)

## Changes

- `create-electron-documentation/templates/fiddle/index.html` (modified)