### PR TITLE
docs: add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -273,6 +273,7 @@ const config: Config = {
     path.resolve(__dirname, './src/plugins/governance/index.ts'),
     path.resolve(__dirname, './src/plugins/markdown-output/index.ts'),
     path.resolve(__dirname, './src/plugins/og-image/index.ts'),
+    'docusaurus-plugin-copy-page-button',
   ],
   presets: [
     [

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "adm-zip": "^0.5.14",
     "ajv": "^8.18.0",
     "clsx": "^1.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "docusaurus-plugin-sass": "^0.2.1",
     "lucide-react": "^0.511.0",
     "prism-react-renderer": "^2.3.1",


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current Electron docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for Electron

Electron already has a custom [`markdown-output` plugin](https://github.com/electron/website/blob/main/src/plugins/markdown-output/index.ts) that publishes `.md` files alongside the HTML — great for AI tools that can fetch the source directly. This plugin is the complementary piece on the front-end: a visible button on every page that lets a developer reading the docs hand the current page off to ChatGPT / Claude / Gemini in one click, instead of figuring out the source URL pattern.

Electron's API surface — IPC, BrowserWindow options, native modules, packaging — is exactly the kind of material developers paste into LLMs while debugging. The button turns that into a single click.

The plugin is currently shipping on Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, Chronicle, and Cardano docs. Also listed in the [official Docusaurus community plugins](https://docusaurus.io/community/resources#plugins).

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `dependencies` in `package.json` (^0.4.2, alphabetical)
- Appends the plugin string to the `plugins` array in `docusaurus.config.ts`, after the existing `markdown-output` and `og-image` plugins

The button auto-injects into the table-of-contents sidebar. No further config required, theme-aware, mobile-friendly, ~5kb client.

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button

Happy to revert or adjust if this doesn't fit the project's direction.