### PR TITLE
blog: A Faster Electron

### DIFF
--- a/blog/a-faster-electron.md
+++ b/blog/a-faster-electron.md
@@ -8,15 +8,15 @@ tags: [internals]
 
 import ThemedImage from '@theme/ThemedImage';
 
-Over the last few releases we've been making Electron faster. Not one feature, and not one benchmark: startup, IPC, `contextBridge`, networking, module loading, and raw JavaScript throughput, across every app that runs on Electron.
+We've spent the last few releases making Electron faster. The work covers startup, IPC, `contextBridge`, networking, module loading, and raw JavaScript throughput, and it applies to every app that runs on Electron.
 
 <div>
   <ThemedImage alt="Electron performance improvements. Startup: sandboxed renderer startup drops from about 230 ms to about 130 ms (about 43%); browser-process startup drops from about 125 ms to about 75 ms (about 40%). Everything after startup: Speedometer 3.1 on an M5 MacBook rises from 56.6 to 66.2 (about 17%); contextBridge calls are about 28% faster overall." sources={{ light: '/assets/img/blog/faster-startup-hero-light.svg', dark: '/assets/img/blog/faster-startup-hero-dark.svg' }} />
 </div>
 
-The short version: **sandboxed renderers** start up **~43%** faster, the **browser process** boots **~40%** faster, and Electron's compiled code itself got faster across the board: **Speedometer is up ~17%**, `contextBridge` calls are up **28-50%**, and networking is up **19-40%**. None of it requires a single change to your app.
+The short version: sandboxed renderers start up ~43% faster, the browser process boots ~40% faster, and Electron's compiled code got quicker across the board. Speedometer is up ~17%, `contextBridge` calls are up 28-50%, and networking is up 19-40%. You don't have to change a line of your app to get any of this.
 
-This post is in two parts. **Part one is startup**: three changes that shrink the time between launching an app and seeing pixels. **Part two is everything after startup**: the discovery that Electron has been shipping with _Chrome's_ compiler optimization data for years, and what fixing that is worth.
+This post is in two parts. The first is startup: three changes that shrink the time between launching an app and seeing pixels. The second is everything after startup, and it begins with the discovery that Electron has been shipping with _Chrome's_ compiler optimization data for years.
 
 <!--truncate-->
 
@@ -26,9 +26,9 @@ Before any of your code runs, a freshly spawned Electron process loads the binar
 
 Part one removes that work from the critical path with three independent changes:
 
-- **Pushing sandboxed-renderer startup data over Mojo** instead of a synchronous IPC, and caching the preload bytecode.
-- **A build-time V8 code cache** for Electron's framework bundles, so they're _deserialized_ instead of _compiled_.
-- **A Node.js startup snapshot for the browser process**, so the Node bootstrap is _restored_ instead of _executed_.
+- Pushing sandboxed-renderer startup data over Mojo instead of a synchronous IPC, and caching the preload bytecode.
+- A build-time V8 code cache for Electron's framework bundles, so they get deserialized instead of compiled.
+- A Node.js startup snapshot for the browser process, so the Node bootstrap gets restored instead of executed.
 
 <div>
   <ThemedImage alt="Two startup timelines. The browser process, from spawn to first user JavaScript, shrinks mainly because the Node.js bootstrap is restored from a snapshot. The sandboxed renderer, from spawn to first paint, shrinks because preload setup is pushed instead of pulled and framework JavaScript comes from a build-time code cache. Bars are illustrative, not to exact scale." sources={{ light: '/assets/img/blog/startup-timeline-light.svg', dark: '/assets/img/blog/startup-timeline-dark.svg' }} />
@@ -36,46 +36,46 @@ Part one removes that work from the critical path with three independent changes
 
 ### Getting the sandboxed renderer off synchronous IPC
 
-A sandboxed renderer historically bootstrapped by asking the browser process for its preload scripts and metadata over a **synchronous** IPC message, then blocking until the answer came back. The catch: at startup the browser process is the busiest it will ever be, so the renderer's cheap request keeps getting preempted by everything else. A reply that takes 2 ms of actual work can land 80 ms later, and the renderer is frozen the whole time.
+A sandboxed renderer historically bootstrapped by asking the browser process for its preload scripts and metadata over a synchronous IPC message, then blocking until the answer came back. The catch: at startup the browser process is the busiest it will ever be, so the renderer's cheap request keeps getting preempted by everything else. A reply that takes 2 ms of actual work can land 80 ms later, and the renderer is frozen the whole time.
 
 <div>
   <ThemedImage alt="Before and after of the synchronous preload IPC. Before: the renderer blocks while the main process is busy with other startup work, so the cheap reply isn't delivered until about 80 ms. After: the main process pushes the bundle one-way during navigation setup and the renderer resumes at about 22 ms." sources={{ light: '/assets/img/blog/sync-ipc-light.svg', dark: '/assets/img/blog/sync-ipc-dark.svg' }} />
 </div>
 
-The fix was to stop asking. The browser process already knows everything the renderer needs, so it now **pushes** that data down with the frame-creation parameters over Mojo. No round-trip, no blocking, and the synchronous message is gone entirely. The preload scripts also gained a **bytecode cache**, so repeat launches deserialize them instead of re-compiling.
+The fix was to stop asking. The browser process already knows everything the renderer needs, so it now pushes that data down with the frame-creation parameters over Mojo, and the synchronous message is gone entirely. The preload scripts also gained a bytecode cache, so repeat launches deserialize them instead of re-compiling.
 
-Together these make sandboxed renderer startup roughly **43% faster** under real-world conditions, and the renderer's pre-paint time no longer depends on how busy your main process is.
+Together these make sandboxed renderer startup roughly 43% faster under real-world conditions, and the renderer's pre-paint time no longer depends on how busy your main process is.
 
 ### A build-time code cache for the framework bundles
 
-Electron's framework JavaScript is embedded in the binary as source, and V8 compiles it from scratch in every process, on every launch. V8 has a standard fix for this, a **code cache**: compile once, serialize the bytecode, deserialize on later runs. We now generate that cache _at build time_ and embed it next to the source, so no process ever compiles the framework bundles again.
+Electron's framework JavaScript is embedded in the binary as source, and V8 compiles it from scratch in every process, on every launch. V8 has a standard fix for this, a code cache: compile once, serialize the bytecode, deserialize on later runs. We now generate that cache at build time and embed it next to the source, so no process ever compiles the framework bundles again.
 
-The catch is that a V8 code cache is keyed to the exact V8 configuration that produced it: the V8 version, the source, the isolate's snapshot checksum, and a hash of V8's non-default flags. If anything differs, V8 silently rejects the cache and compiles from source; no error, just no speedup. And those keys **differ per process type**: a sandboxed renderer, a normal renderer, and the browser process each run V8 with different flags. So the build generates one cache per process flavor, and each process picks up the one that matches it.
+A code cache is only valid for the exact V8 configuration that produced it; if anything differs, V8 silently rejects it and compiles from source, and nothing tells you it happened. Since a sandboxed renderer, a normal renderer, and the browser process each run V8 with different flags, the build generates one cache per process flavor, and each process picks up the one that matches it.
 
 <div>
   <ThemedImage alt="How the build-time code cache works. At build time, Electron's framework JavaScript is compiled once per process flavor, producing five caches (sandbox, renderer, browser, utility, worker), each keyed to that process type's V8 flags. At runtime each process deserializes the cache that matches its own flags; a mismatch is silently rejected and V8 compiles from source." sources={{ light: '/assets/img/blog/code-cache-flow-light.svg', dark: '/assets/img/blog/code-cache-flow-dark.svg' }} />
 </div>
 
-The cache is also built with **eager compilation**, so it covers every inner function rather than just the top level. The framework bundles run in full during bootstrap anyway; this just moves all of that compilation to build time.
+The cache is also built with eager compilation, so it covers every inner function rather than just the top level. The framework bundles run in full during bootstrap anyway; this just moves all of that compilation to build time.
 
 The clearest win is the sandboxed renderer, whose pre-paint blocking window is almost entirely framework compilation:
 
 |                                | Pre-paint blocking window |
 | ------------------------------ | ------------------------- |
 | No cache (compile from source) | ~9.8 ms                   |
-| **Eager build-time cache**     | **~6.4 ms (-35%)**        |
+| Eager build-time cache         | ~6.4 ms (-35%)            |
 
-That's on every launch, embedded in the binary, with no warm-up. The Node-enabled processes consume the cache too, but their startup is dominated by something a code cache can't fix: the Node bootstrap itself. Which brings us to the next change.
+That saving applies on every launch, without any warm-up, because the cache ships inside the binary. The Node-enabled processes consume the cache too, but their startup is dominated by something a code cache can't fix: the Node bootstrap itself.
 
 ### A Node.js startup snapshot for the browser process
 
-A code cache skips _compilation_. The Node.js bootstrap is mostly _execution_: building `process`, wiring the module loader, running ~50 internal setup scripts. Node has a feature designed for exactly this, the **startup snapshot**: serialize a fully bootstrapped environment once, then deserialize it on every launch instead of re-running the bootstrap. Upstream Node ships with it on. Electron has had it disabled for years.
+A code cache skips _compilation_. The Node.js bootstrap is mostly _execution_: building `process`, wiring the module loader, running ~50 internal setup scripts. Node has a feature designed for exactly this, the startup snapshot: serialize a fully bootstrapped environment once, then deserialize it on every launch instead of re-running the bootstrap. Upstream Node ships with it on. Electron has had it disabled for years.
 
 Why? Electron already boots from two snapshots, and neither is Node's:
 
-1. **V8 startup snapshot**: V8's read-only heap and a bare context.
-2. **Blink context snapshot**: the DOM bindings, with zero compiled JavaScript.
-3. **Node snapshot**: the bootstrapped Node environment. _This is the missing one._
+1. The V8 startup snapshot: V8's read-only heap and a bare context.
+2. The Blink context snapshot: the DOM bindings, with zero compiled JavaScript.
+3. The Node snapshot: the bootstrapped Node environment. This is the missing one.
 
 <div>
   <ThemedImage alt="The three snapshot layers stacked: the V8 startup snapshot and the Blink context snapshot were already loaded, but neither captures Node's bootstrap. The Node snapshot, the missing layer, is the one that does." sources={{ light: '/assets/img/blog/snapshot-layers-light.svg', dark: '/assets/img/blog/snapshot-layers-dark.svg' }} />
@@ -83,89 +83,81 @@ Why? Electron already boots from two snapshots, and neither is Node's:
 
 Building the missing one looked impossible at first. Creating a snapshot appears to require a special from-scratch build of V8 that only V8's own tooling gets to use; embedders like Node and Electron only get the "deserialize from an existing snapshot" build, and trying to create a snapshot with it fails with `Heap setup supported only in mksnapshot`.
 
-The way out is that you don't have to build a heap from scratch. You can **extend an existing snapshot**: load the V8 startup snapshot as a base, run Node's bootstrap on top of it, and serialize the result. That's exactly how Chromium builds the Blink context snapshot on every build, with the same "deserialize-only" V8 that Electron has.
+The way out is that you don't have to build a heap from scratch. You can extend an existing snapshot: load the V8 startup snapshot as a base, run Node's bootstrap on top of it, and serialize the result. That's exactly how Chromium builds the Blink context snapshot on every build, with the same "deserialize-only" V8 that Electron has.
 
 <div>
   <ThemedImage alt="Two ways to create a snapshot. Building a heap from scratch needs V8's full setup-isolate delegate, which is only in V8's own mksnapshot and unavailable to embedders. Extending an existing snapshot loads snapshot_blob.bin as a base and uses the deserialize delegate Electron already links, which works." sources={{ light: '/assets/img/blog/extend-not-build-light.svg', dark: '/assets/img/blog/extend-not-build-dark.svg' }} />
 </div>
 
-The snapshot is consumed by the **browser process only**: a renderer's isolate already comes from the Blink snapshot, and V8 allows one snapshot per process. The browser process has no Blink, so Node's snapshot becomes its process-wide blob, and `node::CreateEnvironment` deserializes the environment instead of bootstrapping it.
+The snapshot is consumed by the browser process only: a renderer's isolate already comes from the Blink snapshot, and V8 allows one snapshot per process. The browser process has no Blink, so Node's snapshot becomes its process-wide blob, and `node::CreateEnvironment` deserializes the environment instead of bootstrapping it.
 
-One trap worth sharing if you benchmark this kind of work: measure from process **spawn**, in a **release** build. Local debug-ish builds make snapshot deserialization look artificially slow, and measuring from your entry script's first line misses the entire point, because the win is everything that happens _before_ your script runs. Measured correctly, the Node snapshot is worth roughly **40% of browser-process startup**, about 50 ms on the hardware tested.
+Measured from process spawn in a release build (the win is everything that happens _before_ your entry script runs), the Node snapshot is worth roughly 40% of browser-process startup, about 50 ms on the hardware tested.
 
-### Startup, summed up
+For all three changes, the hard part was the seams rather than the optimizations themselves: Chromium, V8, and Node each have their own model of how a process boots, and the bugs live where those models meet.
 
-- **Sandboxed renderers** skip a synchronous IPC round-trip and reuse cached preload bytecode: **~43% faster**.
-- **Every process** deserializes framework JavaScript instead of compiling it: **~35%** off the pre-paint window.
-- **The browser process** restores its Node.js bootstrap from a snapshot: **~40% faster** to first user JavaScript.
-
-The hardest part of all three wasn't the optimization, it was the seams: Chromium, V8, and Node each have their own model of how a process boots, and the bugs live where those models meet.
-
-Startup is half the story. The other half starts with an uncomfortable discovery about how Electron has been built for years.
+Startup is half the story. The other half starts with something we found while looking at how Electron's release builds are compiled.
 
 ## Part two: Electron has been shipping with Chrome's optimization data
 
-Modern compilers optimize code around how it actually runs. The biggest lever is **Profile-Guided Optimization** (PGO): run an instrumented build through real workloads, record which functions are hot, then rebuild with that profile so the compiler knows what to inline, how to lay out branches, and what to keep in the hot path.
+Modern compilers optimize code around how it actually runs. The biggest lever is Profile-Guided Optimization (PGO): run an instrumented build through real workloads, record which functions are hot, then rebuild with that profile so the compiler knows what to inline, how to lay out branches, and what to keep in the hot path.
 
-Chrome uses PGO aggressively, and Google publishes fresh Chrome profiles every few hours. Here's the uncomfortable part: **Electron's release builds have been applying Chrome's profile.** Not a profile of Electron. Chrome's.
+Chrome uses PGO aggressively, and Google publishes fresh Chrome profiles every few hours. Here's the uncomfortable part: Electron's release builds have been applying Chrome's profile. Not a profile of Electron. Chrome's.
 
 ### What borrowing a profile costs
 
-A profile matches functions by name plus a hash of their code. Functions that exist in Electron but not Chrome (all of Node.js, all of Electron's own C++, `contextBridge`) were never in Chrome's profile. Functions that exist in both but are compiled differently in Electron (different patches, flags, V8 configuration) match by name but fail the hash check and are **silently rejected**. Either way, the compiler gets no guidance and lays the code out as cold.
+A profile matches functions by name plus a hash of their code. Functions that exist in Electron but not Chrome (all of Node.js, all of Electron's own C++, `contextBridge`) were never in Chrome's profile. Functions that exist in both but are compiled differently in Electron (different patches, flags, V8 configuration) match by name but fail the hash check and are silently rejected. Either way, the compiler gets no guidance and lays the code out as cold.
 
-We measured it with `llvm-profdata`: **about a quarter of the code Electron executes gets zero optimization guidance**, and it's concentrated in exactly the code that makes Electron _Electron_.
+We measured it with `llvm-profdata`: about a quarter of the code Electron executes gets zero optimization guidance, and it's concentrated in exactly the code that makes Electron _Electron_.
 
 <div>
   <ThemedImage alt="What Chrome's profile knows about Electron's code: 74.5% is optimized (name and hash match), 19.3% is silently rejected (same name, different code: Skia SIMD kernels, V8's JSON stringifier, Mojo, net), and 6.2% is not in Chrome's profile at all (all of Node.js, contextBridge, Electron's own C++). One quarter of the code Electron executes gets zero optimization guidance." sources={{ light: '/assets/img/blog/pgo-coverage-light.svg', dark: '/assets/img/blog/pgo-coverage-dark.svg' }} />
 </div>
 
-This isn't theoretical. While doing this work we found that `crypto.randomBytes` in Electron 44 runs at **less than half** its Electron 42 speed. Nobody touched the crypto code: a BoringSSL patch changed the functions' hashes, Chrome's profile silently stopped covering them, and the compiler started treating them as cold. That's what makes a borrowed profile insidious: code gets slower without anyone changing it, and nothing warns you. With an Electron profile, the regression disappears.
+This isn't theoretical. While doing this work we found that `crypto.randomBytes` in Electron 44 runs at less than half its Electron 42 speed. Nobody touched the crypto code: a BoringSSL patch changed the functions' hashes, Chrome's profile silently stopped covering them, and the compiler started treating them as cold. That's what makes a borrowed profile insidious: code gets slower without anyone changing it, and nothing warns you. With an Electron profile, the regression disappears.
 
 ### Fix one: turn on link-time optimization
 
-Chromium links with **ThinLTO**, which lets the compiler optimize across source files at link time, but the default setting does no optimization at all (`--lto-O0`). Chrome's release builds opt into `--lto-O2`. Electron never did.
+Chromium links with ThinLTO, which lets the compiler optimize across source files at link time, but the default setting does no optimization at all (`--lto-O0`). Chrome's release builds opt into `--lto-O2`. Electron never did.
 
-Opting in is worth about **+5%** on Speedometer 3.1 on an M5 MacBook (and more on older hardware). Useful, but as it turns out, the smaller half of the story.
+Opting in is worth about +5% on Speedometer 3.1 on an M5 MacBook (and more on older hardware). Useful, but as it turns out, the smaller of the two fixes.
 
 ### Fix two: Electron's own profiles
 
 If borrowing Chrome's profile is the problem, the fix is to train our own: instrumented builds for every release platform, training workloads that exercise Electron the way apps actually use it, and a pipeline that publishes the profiles for release builds to consume.
 
-The training workloads turn out to be the entire game, because PGO is symmetric: everything the training runs gets optimized, and everything it _doesn't_ run gets explicitly laid out as cold. Our first profile was trained on browser benchmarks. Browser-style code got faster, and Node.js `Buffer` operations got **63% slower than stock**, because the training never ran Node.
+The training workloads turn out to be the entire game, because PGO is symmetric: everything the training runs gets optimized, and everything it _doesn't_ run gets explicitly laid out as cold. Our first profile was trained on browser benchmarks. Browser-style code got faster, and Node.js `Buffer` operations got 63% slower than stock, because the training never ran Node.
 
 <div>
   <ThemedImage alt="The cold-marking trap. A profile trained only on browser benchmarks: browser-style code gets 13% faster, but Node.js Buffer operations get 63% slower than stock because the training never ran Node and the profile marked it cold. The enriched profile, trained on Node.js, contextBridge, IPC, TLS networking, and ASAR module loading as well as browser workloads, keeps the browser wins and fully recovers Node." sources={{ light: '/assets/img/blog/cold-marking-light.svg', dark: '/assets/img/blog/cold-marking-dark.svg' }} />
 </div>
 
-The training suite now covers what Electron apps actually do: main-process Node.js, `contextBridge` and IPC marshaling, networking over real TLS, module loading from ASAR archives, and compression. It also covers V8's **builtins**, which have their own separate profile; Chrome's version rejects every promise and async builtin in Electron (we build V8 with promise hooks enabled, Chrome doesn't), so those were running unoptimized too.
+The training suite now covers what Electron apps actually do: main-process Node.js, `contextBridge` and IPC marshaling, networking over real TLS, module loading from ASAR archives, and compression. It also covers V8's builtins, which have their own separate profile; Chrome's version rejects every promise and async builtin in Electron (we build V8 with promise hooks enabled, Chrome doesn't), so those were running unoptimized too.
 
 ### The results
 
 Each layer stacks on the last. On Speedometer 3.1, on an M5 MacBook:
 
-| Configuration              | Score    | Step     |
-| -------------------------- | -------- | -------- |
-| Stock Electron             | 56.6     |          |
-| + ThinLTO `--lto-O2`       | 59.2     | +5%      |
-| + Electron C++ PGO         | 65.5     | **+11%** |
-| + Electron V8 builtins PGO | **66.2** | +1%      |
+| Configuration              | Score | Step |
+| -------------------------- | ----- | ---- |
+| Stock Electron             | 56.6  |      |
+| + ThinLTO `--lto-O2`       | 59.2  | +5%  |
+| + Electron C++ PGO         | 65.5  | +11% |
+| + Electron V8 builtins PGO | 66.2  | +1%  |
 
-That's **+17% end to end**, and the biggest single step is Electron's own profile, not the compiler flag. The borrowed optimization data really was the main problem.
+That's +17% end to end, and the biggest single step is Electron's own profile, not the compiler flag. The borrowed optimization data really was the main problem.
 
 <div>
   <ThemedImage alt="Speedometer 3.1 on an M5 MacBook as each layer is added: stock Electron 56.6, plus ThinLTO 59.2 (+5%), plus Electron's C++ PGO 65.5 (+11%, the largest step), plus Electron's V8 builtins PGO 66.2. Total +17%, and the biggest gain comes from replacing Chrome's borrowed profile with Electron's own." sources={{ light: '/assets/img/blog/speedometer-stack-light.svg', dark: '/assets/img/blog/speedometer-stack-dark.svg' }} />
 </div>
 
-We also validated the whole stack against the official nightly across a 38-test suite covering `contextBridge`, IPC, and networking, with statistical significance testing:
-
-**37 significant improvements, zero regressions, one tie.**
+We also validated the whole stack against the official nightly across a 38-test suite covering `contextBridge`, IPC, and networking, with statistical significance testing: 37 significant improvements, zero regressions, and one tie.
 
 | Area                                     | Improvement (geomean) |
 | ---------------------------------------- | --------------------- |
-| `contextBridge`                          | **+28%**              |
-| Networking (`fetch`, WebSocket, `https`) | **+19%**              |
-| IPC                                      | **+11%**              |
-| Overall                                  | **+19.5%**            |
+| `contextBridge`                          | +28%                  |
+| Networking (`fetch`, WebSocket, `https`) | +19%                  |
+| IPC                                      | +11%                  |
+| Overall                                  | +19.5%                |
 
 The wins land exactly where Electron's own code runs: `contextBridge` calls that round-trip objects are up 40-55%, `fetch` round-trips are up 23-40%, IPC payloads of every size are up 7-16%. On identical workloads, an optimized Electron now matches or exceeds Chrome itself; the penalty for being "Chrome plus Node.js" instead of Chrome is gone.
 
@@ -181,8 +173,8 @@ A useful frame: a UI interaction that costs 19.7 ms today misses the 60 fps fram
 
 ## Putting it together
 
-- **Startup**: sandboxed renderers start ~43% faster, framework JavaScript comes from an embedded code cache, and the browser process restores its Node.js bootstrap from a snapshot.
-- **Everything after**: Electron stopped borrowing Chrome's compiler optimization data and started generating its own, removing a silent ~20-25% CPU penalty on its hottest code paths.
+- Startup: sandboxed renderers start ~43% faster, framework JavaScript comes from an embedded code cache, and the browser process restores its Node.js bootstrap from a snapshot.
+- Everything after: Electron stopped borrowing Chrome's compiler optimization data and started generating its own, removing a silent ~20-25% CPU penalty on its hottest code paths.
 
 Apps don't need to do anything except update.
 

--- a/blog/a-faster-electron.md
+++ b/blog/a-faster-electron.md
@@ -3,20 +3,20 @@ title: 'A Faster Electron'
 date: 2026-05-20T00:00:00.000Z
 authors: MarshallOfSound
 slug: a-faster-electron
-tags: [internals]
+tags: [techtalk, internals]
 ---
 
 import ThemedImage from '@theme/ThemedImage';
 
-We've spent the last few releases making Electron faster. The work covers startup, IPC, `contextBridge`, networking, module loading, and raw JavaScript throughput, and it applies to every app that runs on Electron.
+We've spent the last few releases making Electron faster. The work covers startup, IPC, `contextBridge`, networking, module loading, and raw JavaScript throughput, and it applies to every app that runs on Electron. It ships today in Electron 42.3.3, 43.0.0-beta.1, and 44.0.0-nightly.20260603.
 
 <div>
-  <ThemedImage alt="Electron performance improvements. Startup: sandboxed renderer startup drops from about 230 ms to about 130 ms (about 43%); browser-process startup drops from about 125 ms to about 75 ms (about 40%). Everything after startup: Speedometer 3.1 on an M5 MacBook rises from 56.6 to 66.2 (about 17%); contextBridge calls are about 28% faster overall." sources={{ light: '/assets/img/blog/faster-startup-hero-light.svg', dark: '/assets/img/blog/faster-startup-hero-dark.svg' }} />
+  <ThemedImage alt="Electron performance improvements. Startup: sandboxed renderer startup drops from about 230 ms to about 130 ms (about 43%); main-process startup drops from about 125 ms to about 75 ms (about 40%). Everything after startup: Speedometer 3.1 on an M5 MacBook rises from 56.6 to 66.2 (about 17%); contextBridge calls are about 28% faster overall." sources={{ light: '/assets/img/blog/faster-startup-hero-light.svg', dark: '/assets/img/blog/faster-startup-hero-dark.svg' }} />
 </div>
 
-The short version: sandboxed renderers start up ~43% faster, the browser process boots ~40% faster, and Electron's compiled code got quicker across the board. Speedometer is up ~17%, `contextBridge` calls are up 28-50%, and networking is up 19-40%. You don't have to change a line of your app to get any of this.
+The short version: sandboxed renderers start up ~43% faster, the main process boots ~40% faster, and Electron's compiled code got quicker across the board. Speedometer is up ~17%, `contextBridge` calls are up 28-50%, and networking is up 19-40%. You don't have to change a line of your app to get any of this.
 
-This post is in two parts. The first is startup: three changes that shrink the time between launching an app and seeing pixels. The second is everything after startup, and it begins with the discovery that Electron has been shipping with _Chrome's_ compiler optimization data for years.
+This post is in two parts. The first is startup: three changes that shrink the time between launching an app and seeing pixels. The second is everything after startup, and it begins with the discovery that Electron's release builds have spent years borrowing Chrome's compiler optimization data, which is almost, but not quite, right for Electron.
 
 <!--truncate-->
 
@@ -26,34 +26,34 @@ Before any of your code runs, a freshly spawned Electron process loads the binar
 
 Part one removes that work from the critical path with three independent changes:
 
-- Pushing sandboxed-renderer startup data over Mojo instead of a synchronous IPC, and caching the preload bytecode.
+- Pushing sandboxed-renderer startup data over [Mojo](https://chromium.googlesource.com/chromium/src/+/HEAD/mojo/README.md) instead of a synchronous IPC, and caching the preload bytecode.
 - A build-time V8 code cache for Electron's framework bundles, so they get deserialized instead of compiled.
-- A Node.js startup snapshot for the browser process, so the Node bootstrap gets restored instead of executed.
+- A Node.js startup snapshot for the main process, so the Node bootstrap gets restored instead of executed.
 
 <div>
-  <ThemedImage alt="Two startup timelines. The browser process, from spawn to first user JavaScript, shrinks mainly because the Node.js bootstrap is restored from a snapshot. The sandboxed renderer, from spawn to first paint, shrinks because preload setup is pushed instead of pulled and framework JavaScript comes from a build-time code cache. Bars are illustrative, not to exact scale." sources={{ light: '/assets/img/blog/startup-timeline-light.svg', dark: '/assets/img/blog/startup-timeline-dark.svg' }} />
+  <ThemedImage alt="Two startup timelines. The main process, from spawn to first user JavaScript, shrinks mainly because the Node.js bootstrap is restored from a snapshot. The sandboxed renderer, from spawn to first paint, shrinks because preload setup is pushed instead of pulled and framework JavaScript comes from a build-time code cache. Bars are illustrative, not to exact scale." sources={{ light: '/assets/img/blog/startup-timeline-light.svg', dark: '/assets/img/blog/startup-timeline-dark.svg' }} />
 </div>
 
 ### Getting the sandboxed renderer off synchronous IPC
 
-A sandboxed renderer historically bootstrapped by asking the browser process for its preload scripts and metadata over a synchronous IPC message, then blocking until the answer came back. The catch: at startup the browser process is the busiest it will ever be, so the renderer's cheap request keeps getting preempted by everything else. A reply that takes 2 ms of actual work can land 80 ms later, and the renderer is frozen the whole time.
+A sandboxed renderer historically bootstrapped by asking the main process for its preload scripts and metadata over a synchronous IPC message, then blocking until the answer came back. The catch: at startup the main process is the busiest it will ever be, so the renderer's cheap request keeps getting preempted by everything else. A reply that takes 2 ms of actual work can land 80 ms later, and the renderer is frozen the whole time.
 
 <div>
   <ThemedImage alt="Before and after of the synchronous preload IPC. Before: the renderer blocks while the main process is busy with other startup work, so the cheap reply isn't delivered until about 80 ms. After: the main process pushes the bundle one-way during navigation setup and the renderer resumes at about 22 ms." sources={{ light: '/assets/img/blog/sync-ipc-light.svg', dark: '/assets/img/blog/sync-ipc-dark.svg' }} />
 </div>
 
-The fix was to stop asking. The browser process already knows everything the renderer needs, so it now pushes that data down with the frame-creation parameters over Mojo, and the synchronous message is gone entirely. The preload scripts also gained a bytecode cache, so repeat launches deserialize them instead of re-compiling.
+The fix was to stop asking. The main process already knows everything the renderer needs, so it now pushes that data down with the frame-creation parameters over Mojo, and the synchronous message is gone entirely. The preload scripts also gained a bytecode cache, so repeat launches deserialize them instead of re-compiling.
 
 Together these make sandboxed renderer startup roughly 43% faster under real-world conditions, and the renderer's pre-paint time no longer depends on how busy your main process is.
 
 ### A build-time code cache for the framework bundles
 
-Electron's framework JavaScript is embedded in the binary as source, and V8 compiles it from scratch in every process, on every launch. V8 has a standard fix for this, a code cache: compile once, serialize the bytecode, deserialize on later runs. We now generate that cache at build time and embed it next to the source, so no process ever compiles the framework bundles again.
+Electron's framework JavaScript is embedded in the binary as source, and V8 has always compiled it from scratch in every process, on every launch. V8 has a standard fix for this, a code cache: compile once, serialize the bytecode, deserialize on later runs. Electron just never used it. We now generate that cache at build time and embed it next to the source, so no process ever compiles the framework bundles again.
 
-A code cache is only valid for the exact V8 configuration that produced it; if anything differs, V8 silently rejects it and compiles from source, and nothing tells you it happened. Since a sandboxed renderer, a normal renderer, and the browser process each run V8 with different flags, the build generates one cache per process flavor, and each process picks up the one that matches it.
+A code cache is only valid for the exact V8 configuration that produced it; if anything differs, V8 silently rejects it and compiles from source, and nothing tells you it happened. Since a sandboxed renderer, a normal renderer, and the main process each run V8 with different flags, the build generates one cache per process flavor, and each process picks up the one that matches it.
 
 <div>
-  <ThemedImage alt="How the build-time code cache works. At build time, Electron's framework JavaScript is compiled once per process flavor, producing five caches (sandbox, renderer, browser, utility, worker), each keyed to that process type's V8 flags. At runtime each process deserializes the cache that matches its own flags; a mismatch is silently rejected and V8 compiles from source." sources={{ light: '/assets/img/blog/code-cache-flow-light.svg', dark: '/assets/img/blog/code-cache-flow-dark.svg' }} />
+  <ThemedImage alt="How the build-time code cache works. At build time, Electron's framework JavaScript is compiled once per process flavor, producing five caches (sandbox, renderer, main, utility, worker), each keyed to that process type's V8 flags. At runtime each process deserializes the cache that matches its own flags; a mismatch is silently rejected and V8 compiles from source." sources={{ light: '/assets/img/blog/code-cache-flow-light.svg', dark: '/assets/img/blog/code-cache-flow-dark.svg' }} />
 </div>
 
 The cache is also built with eager compilation, so it covers every inner function rather than just the top level. The framework bundles run in full during bootstrap anyway; this just moves all of that compilation to build time.
@@ -67,15 +67,11 @@ The clearest win is the sandboxed renderer, whose pre-paint blocking window is a
 
 That saving applies on every launch, without any warm-up, because the cache ships inside the binary. The Node-enabled processes consume the cache too, but their startup is dominated by something a code cache can't fix: the Node bootstrap itself.
 
-### A Node.js startup snapshot for the browser process
+### A Node.js startup snapshot for the main process
 
 A code cache skips _compilation_. The Node.js bootstrap is mostly _execution_: building `process`, wiring the module loader, running ~50 internal setup scripts. Node has a feature designed for exactly this, the startup snapshot: serialize a fully bootstrapped environment once, then deserialize it on every launch instead of re-running the bootstrap. Upstream Node ships with it on. Electron has had it disabled for years.
 
-Why? Electron already boots from two snapshots, and neither is Node's:
-
-1. The V8 startup snapshot: V8's read-only heap and a bare context.
-2. The Blink context snapshot: the DOM bindings, with zero compiled JavaScript.
-3. The Node snapshot: the bootstrapped Node environment. This is the missing one.
+Why? Electron already boots from two snapshots, the V8 startup snapshot (V8's read-only heap and a bare context) and the Blink context snapshot (the DOM bindings, with zero compiled JavaScript), and neither captures Node's bootstrap. The Node snapshot would be the missing third layer.
 
 <div>
   <ThemedImage alt="The three snapshot layers stacked: the V8 startup snapshot and the Blink context snapshot were already loaded, but neither captures Node's bootstrap. The Node snapshot, the missing layer, is the one that does." sources={{ light: '/assets/img/blog/snapshot-layers-light.svg', dark: '/assets/img/blog/snapshot-layers-dark.svg' }} />
@@ -89,9 +85,9 @@ The way out is that you don't have to build a heap from scratch. You can extend 
   <ThemedImage alt="Two ways to create a snapshot. Building a heap from scratch needs V8's full setup-isolate delegate, which is only in V8's own mksnapshot and unavailable to embedders. Extending an existing snapshot loads snapshot_blob.bin as a base and uses the deserialize delegate Electron already links, which works." sources={{ light: '/assets/img/blog/extend-not-build-light.svg', dark: '/assets/img/blog/extend-not-build-dark.svg' }} />
 </div>
 
-The snapshot is consumed by the browser process only: a renderer's isolate already comes from the Blink snapshot, and V8 allows one snapshot per process. The browser process has no Blink, so Node's snapshot becomes its process-wide blob, and `node::CreateEnvironment` deserializes the environment instead of bootstrapping it.
+The snapshot is consumed by the main process only: a renderer's isolate already comes from the Blink snapshot, and V8 allows one snapshot per process. The main process has no Blink, so Node's snapshot becomes its process-wide blob, and `node::CreateEnvironment` deserializes the environment instead of bootstrapping it.
 
-Measured from process spawn in a release build (the win is everything that happens _before_ your entry script runs), the Node snapshot is worth roughly 40% of browser-process startup, about 50 ms on the hardware tested.
+Measured from process spawn in a release build (the win is everything that happens _before_ your entry script runs), the Node snapshot is worth roughly 40% of main-process startup, about 50 ms on the hardware tested.
 
 For all three changes, the hard part was the seams rather than the optimizations themselves: Chromium, V8, and Node each have their own model of how a process boots, and the bugs live where those models meet.
 
@@ -99,15 +95,15 @@ Startup is half the story. The other half starts with something we found while l
 
 ## Part two: Electron has been shipping with Chrome's optimization data
 
-Modern compilers optimize code around how it actually runs. The biggest lever is Profile-Guided Optimization (PGO): run an instrumented build through real workloads, record which functions are hot, then rebuild with that profile so the compiler knows what to inline, how to lay out branches, and what to keep in the hot path.
+Modern compilers optimize code around how it actually runs. The biggest lever is [Profile-Guided Optimization](https://chromium.googlesource.com/chromium/src.git/+/HEAD/docs/pgo.md) (PGO): run an instrumented build through real workloads, record which functions are hot, then rebuild with that profile so the compiler knows what to inline, how to lay out branches, and what to keep in the hot path.
 
-Chrome uses PGO aggressively, and Google publishes fresh Chrome profiles every few hours. Here's the uncomfortable part: Electron's release builds have been applying Chrome's profile. Not a profile of Electron. Chrome's.
+Chrome uses PGO aggressively, and Google publishes fresh Chrome profiles every few hours. Electron's release builds have been applying Chrome's profile rather than one trained on Electron. That profile is mostly right for Electron too, which is exactly why the parts it gets wrong went unnoticed.
 
 ### What borrowing a profile costs
 
 A profile matches functions by name plus a hash of their code. Functions that exist in Electron but not Chrome (all of Node.js, all of Electron's own C++, `contextBridge`) were never in Chrome's profile. Functions that exist in both but are compiled differently in Electron (different patches, flags, V8 configuration) match by name but fail the hash check and are silently rejected. Either way, the compiler gets no guidance and lays the code out as cold.
 
-We measured it with `llvm-profdata`: about a quarter of the code Electron executes gets zero optimization guidance, and it's concentrated in exactly the code that makes Electron _Electron_.
+We measured it with [`llvm-profdata`](https://llvm.org/docs/CommandGuide/llvm-profdata.html): about a quarter of the code Electron executes gets zero optimization guidance, and it's concentrated in exactly the code that makes Electron _Electron_.
 
 <div>
   <ThemedImage alt="What Chrome's profile knows about Electron's code: 74.5% is optimized (name and hash match), 19.3% is silently rejected (same name, different code: Skia SIMD kernels, V8's JSON stringifier, Mojo, net), and 6.2% is not in Chrome's profile at all (all of Node.js, contextBridge, Electron's own C++). One quarter of the code Electron executes gets zero optimization guidance." sources={{ light: '/assets/img/blog/pgo-coverage-light.svg', dark: '/assets/img/blog/pgo-coverage-dark.svg' }} />
@@ -115,13 +111,13 @@ We measured it with `llvm-profdata`: about a quarter of the code Electron execut
 
 This isn't theoretical. While doing this work we found that `crypto.randomBytes` in Electron 44 runs at less than half its Electron 42 speed. Nobody touched the crypto code: a BoringSSL patch changed the functions' hashes, Chrome's profile silently stopped covering them, and the compiler started treating them as cold. That's what makes a borrowed profile insidious: code gets slower without anyone changing it, and nothing warns you. With an Electron profile, the regression disappears.
 
-### Fix one: turn on link-time optimization
+### Turning on link-time optimization
 
 Chromium links with ThinLTO, which lets the compiler optimize across source files at link time, but the default setting does no optimization at all (`--lto-O0`). Chrome's release builds opt into `--lto-O2`. Electron never did.
 
-Opting in is worth about +5% on Speedometer 3.1 on an M5 MacBook (and more on older hardware). Useful, but as it turns out, the smaller of the two fixes.
+Opting in is worth about +5% on [Speedometer 3.1](https://browserbench.org/Speedometer3.1/), the industry-standard benchmark of web-app responsiveness, on an M5 MacBook (and more on older hardware). Useful, but as it turns out, the smaller of the two fixes.
 
-### Fix two: Electron's own profiles
+### Electron's own profiles
 
 If borrowing Chrome's profile is the problem, the fix is to train our own: instrumented builds for every release platform, training workloads that exercise Electron the way apps actually use it, and a pipeline that publishes the profiles for release builds to consume.
 
@@ -135,7 +131,7 @@ The training suite now covers what Electron apps actually do: main-process Node.
 
 ### The results
 
-Each layer stacks on the last. On Speedometer 3.1, on an M5 MacBook:
+Each layer stacks on the last. On Speedometer 3.1, on an M5 MacBook, starting from a stock nightly build from before this work landed:
 
 | Configuration              | Score | Step |
 | -------------------------- | ----- | ---- |
@@ -144,13 +140,13 @@ Each layer stacks on the last. On Speedometer 3.1, on an M5 MacBook:
 | + Electron C++ PGO         | 65.5  | +11% |
 | + Electron V8 builtins PGO | 66.2  | +1%  |
 
-That's +17% end to end, and the biggest single step is Electron's own profile, not the compiler flag. The borrowed optimization data really was the main problem.
+That's a +17% end-to-end score increase, with the dedicated Electron performance profiles providing most of the results. Other platforms show similar effects, though we haven't measured them as precisely.
 
 <div>
   <ThemedImage alt="Speedometer 3.1 on an M5 MacBook as each layer is added: stock Electron 56.6, plus ThinLTO 59.2 (+5%), plus Electron's C++ PGO 65.5 (+11%, the largest step), plus Electron's V8 builtins PGO 66.2. Total +17%, and the biggest gain comes from replacing Chrome's borrowed profile with Electron's own." sources={{ light: '/assets/img/blog/speedometer-stack-light.svg', dark: '/assets/img/blog/speedometer-stack-dark.svg' }} />
 </div>
 
-We also validated the whole stack against the official nightly across a 38-test suite covering `contextBridge`, IPC, and networking, with statistical significance testing: 37 significant improvements, zero regressions, and one tie.
+The same builds, measured on Electron-specific workloads:
 
 | Area                                     | Improvement (geomean) |
 | ---------------------------------------- | --------------------- |
@@ -173,9 +169,9 @@ A useful frame: a UI interaction that costs 19.7 ms today misses the 60 fps fram
 
 ## Putting it together
 
-- Startup: sandboxed renderers start ~43% faster, framework JavaScript comes from an embedded code cache, and the browser process restores its Node.js bootstrap from a snapshot.
+- Startup: sandboxed renderers start ~43% faster, framework JavaScript comes from an embedded code cache, and the main process restores its Node.js bootstrap from a snapshot.
 - Everything after: Electron stopped borrowing Chrome's compiler optimization data and started generating its own, removing a silent ~20-25% CPU penalty on its hottest code paths.
 
-Apps don't need to do anything except update.
+Apps don't need to do anything except update: everything here ships in Electron 42.3.3, 43.0.0-beta.1, and 44.0.0-nightly.20260603.
 
 If this kind of work sounds fun, the [Electron repository](https://github.com/electron/electron) is always looking for contributors.

--- a/blog/a-faster-electron.md
+++ b/blog/a-faster-electron.md
@@ -1,0 +1,189 @@
+---
+title: 'A Faster Electron'
+date: 2026-05-20T00:00:00.000Z
+authors: MarshallOfSound
+slug: a-faster-electron
+tags: [internals]
+---
+
+import ThemedImage from '@theme/ThemedImage';
+
+Over the last few releases we've been making Electron faster. Not one feature, and not one benchmark: startup, IPC, `contextBridge`, networking, module loading, and raw JavaScript throughput, across every app that runs on Electron.
+
+<div>
+  <ThemedImage alt="Electron performance improvements. Startup: sandboxed renderer startup drops from about 230 ms to about 130 ms (about 43%); browser-process startup drops from about 125 ms to about 75 ms (about 40%). Everything after startup: Speedometer 3.1 on an M5 MacBook rises from 56.6 to 66.2 (about 17%); contextBridge calls are about 28% faster overall." sources={{ light: '/assets/img/blog/faster-startup-hero-light.svg', dark: '/assets/img/blog/faster-startup-hero-dark.svg' }} />
+</div>
+
+The short version: **sandboxed renderers** start up **~43%** faster, the **browser process** boots **~40%** faster, and Electron's compiled code itself got faster across the board: **Speedometer is up ~17%**, `contextBridge` calls are up **28-50%**, and networking is up **19-40%**. None of it requires a single change to your app.
+
+This post is in two parts. **Part one is startup**: three changes that shrink the time between launching an app and seeing pixels. **Part two is everything after startup**: the discovery that Electron has been shipping with _Chrome's_ compiler optimization data for years, and what fixing that is worth.
+
+<!--truncate-->
+
+## Part one: faster startup
+
+Before any of your code runs, a freshly spawned Electron process loads the binary, initializes Chromium and V8, bootstraps a Node.js environment (where it has one), and parses and compiles Electron's own framework JavaScript. The last two are pure CPU spent turning JavaScript into bytecode, and they happen on _every launch of every process_.
+
+Part one removes that work from the critical path with three independent changes:
+
+- **Pushing sandboxed-renderer startup data over Mojo** instead of a synchronous IPC, and caching the preload bytecode.
+- **A build-time V8 code cache** for Electron's framework bundles, so they're _deserialized_ instead of _compiled_.
+- **A Node.js startup snapshot for the browser process**, so the Node bootstrap is _restored_ instead of _executed_.
+
+<div>
+  <ThemedImage alt="Two startup timelines. The browser process, from spawn to first user JavaScript, shrinks mainly because the Node.js bootstrap is restored from a snapshot. The sandboxed renderer, from spawn to first paint, shrinks because preload setup is pushed instead of pulled and framework JavaScript comes from a build-time code cache. Bars are illustrative, not to exact scale." sources={{ light: '/assets/img/blog/startup-timeline-light.svg', dark: '/assets/img/blog/startup-timeline-dark.svg' }} />
+</div>
+
+### Getting the sandboxed renderer off synchronous IPC
+
+A sandboxed renderer historically bootstrapped by asking the browser process for its preload scripts and metadata over a **synchronous** IPC message, then blocking until the answer came back. The catch: at startup the browser process is the busiest it will ever be, so the renderer's cheap request keeps getting preempted by everything else. A reply that takes 2 ms of actual work can land 80 ms later, and the renderer is frozen the whole time.
+
+<div>
+  <ThemedImage alt="Before and after of the synchronous preload IPC. Before: the renderer blocks while the main process is busy with other startup work, so the cheap reply isn't delivered until about 80 ms. After: the main process pushes the bundle one-way during navigation setup and the renderer resumes at about 22 ms." sources={{ light: '/assets/img/blog/sync-ipc-light.svg', dark: '/assets/img/blog/sync-ipc-dark.svg' }} />
+</div>
+
+The fix was to stop asking. The browser process already knows everything the renderer needs, so it now **pushes** that data down with the frame-creation parameters over Mojo. No round-trip, no blocking, and the synchronous message is gone entirely. The preload scripts also gained a **bytecode cache**, so repeat launches deserialize them instead of re-compiling.
+
+Together these make sandboxed renderer startup roughly **43% faster** under real-world conditions, and the renderer's pre-paint time no longer depends on how busy your main process is.
+
+### A build-time code cache for the framework bundles
+
+Electron's framework JavaScript is embedded in the binary as source, and V8 compiles it from scratch in every process, on every launch. V8 has a standard fix for this, a **code cache**: compile once, serialize the bytecode, deserialize on later runs. We now generate that cache _at build time_ and embed it next to the source, so no process ever compiles the framework bundles again.
+
+The catch is that a V8 code cache is keyed to the exact V8 configuration that produced it: the V8 version, the source, the isolate's snapshot checksum, and a hash of V8's non-default flags. If anything differs, V8 silently rejects the cache and compiles from source; no error, just no speedup. And those keys **differ per process type**: a sandboxed renderer, a normal renderer, and the browser process each run V8 with different flags. So the build generates one cache per process flavor, and each process picks up the one that matches it.
+
+<div>
+  <ThemedImage alt="How the build-time code cache works. At build time, Electron's framework JavaScript is compiled once per process flavor, producing five caches (sandbox, renderer, browser, utility, worker), each keyed to that process type's V8 flags. At runtime each process deserializes the cache that matches its own flags; a mismatch is silently rejected and V8 compiles from source." sources={{ light: '/assets/img/blog/code-cache-flow-light.svg', dark: '/assets/img/blog/code-cache-flow-dark.svg' }} />
+</div>
+
+The cache is also built with **eager compilation**, so it covers every inner function rather than just the top level. The framework bundles run in full during bootstrap anyway; this just moves all of that compilation to build time.
+
+The clearest win is the sandboxed renderer, whose pre-paint blocking window is almost entirely framework compilation:
+
+|                                | Pre-paint blocking window |
+| ------------------------------ | ------------------------- |
+| No cache (compile from source) | ~9.8 ms                   |
+| **Eager build-time cache**     | **~6.4 ms (-35%)**        |
+
+That's on every launch, embedded in the binary, with no warm-up. The Node-enabled processes consume the cache too, but their startup is dominated by something a code cache can't fix: the Node bootstrap itself. Which brings us to the next change.
+
+### A Node.js startup snapshot for the browser process
+
+A code cache skips _compilation_. The Node.js bootstrap is mostly _execution_: building `process`, wiring the module loader, running ~50 internal setup scripts. Node has a feature designed for exactly this, the **startup snapshot**: serialize a fully bootstrapped environment once, then deserialize it on every launch instead of re-running the bootstrap. Upstream Node ships with it on. Electron has had it disabled for years.
+
+Why? Electron already boots from two snapshots, and neither is Node's:
+
+1. **V8 startup snapshot**: V8's read-only heap and a bare context.
+2. **Blink context snapshot**: the DOM bindings, with zero compiled JavaScript.
+3. **Node snapshot**: the bootstrapped Node environment. _This is the missing one._
+
+<div>
+  <ThemedImage alt="The three snapshot layers stacked: the V8 startup snapshot and the Blink context snapshot were already loaded, but neither captures Node's bootstrap. The Node snapshot, the missing layer, is the one that does." sources={{ light: '/assets/img/blog/snapshot-layers-light.svg', dark: '/assets/img/blog/snapshot-layers-dark.svg' }} />
+</div>
+
+Building the missing one looked impossible at first. Creating a snapshot appears to require a special from-scratch build of V8 that only V8's own tooling gets to use; embedders like Node and Electron only get the "deserialize from an existing snapshot" build, and trying to create a snapshot with it fails with `Heap setup supported only in mksnapshot`.
+
+The way out is that you don't have to build a heap from scratch. You can **extend an existing snapshot**: load the V8 startup snapshot as a base, run Node's bootstrap on top of it, and serialize the result. That's exactly how Chromium builds the Blink context snapshot on every build, with the same "deserialize-only" V8 that Electron has.
+
+<div>
+  <ThemedImage alt="Two ways to create a snapshot. Building a heap from scratch needs V8's full setup-isolate delegate, which is only in V8's own mksnapshot and unavailable to embedders. Extending an existing snapshot loads snapshot_blob.bin as a base and uses the deserialize delegate Electron already links, which works." sources={{ light: '/assets/img/blog/extend-not-build-light.svg', dark: '/assets/img/blog/extend-not-build-dark.svg' }} />
+</div>
+
+The snapshot is consumed by the **browser process only**: a renderer's isolate already comes from the Blink snapshot, and V8 allows one snapshot per process. The browser process has no Blink, so Node's snapshot becomes its process-wide blob, and `node::CreateEnvironment` deserializes the environment instead of bootstrapping it.
+
+One trap worth sharing if you benchmark this kind of work: measure from process **spawn**, in a **release** build. Local debug-ish builds make snapshot deserialization look artificially slow, and measuring from your entry script's first line misses the entire point, because the win is everything that happens _before_ your script runs. Measured correctly, the Node snapshot is worth roughly **40% of browser-process startup**, about 50 ms on the hardware tested.
+
+### Startup, summed up
+
+- **Sandboxed renderers** skip a synchronous IPC round-trip and reuse cached preload bytecode: **~43% faster**.
+- **Every process** deserializes framework JavaScript instead of compiling it: **~35%** off the pre-paint window.
+- **The browser process** restores its Node.js bootstrap from a snapshot: **~40% faster** to first user JavaScript.
+
+The hardest part of all three wasn't the optimization, it was the seams: Chromium, V8, and Node each have their own model of how a process boots, and the bugs live where those models meet.
+
+Startup is half the story. The other half starts with an uncomfortable discovery about how Electron has been built for years.
+
+## Part two: Electron has been shipping with Chrome's optimization data
+
+Modern compilers optimize code around how it actually runs. The biggest lever is **Profile-Guided Optimization** (PGO): run an instrumented build through real workloads, record which functions are hot, then rebuild with that profile so the compiler knows what to inline, how to lay out branches, and what to keep in the hot path.
+
+Chrome uses PGO aggressively, and Google publishes fresh Chrome profiles every few hours. Here's the uncomfortable part: **Electron's release builds have been applying Chrome's profile.** Not a profile of Electron. Chrome's.
+
+### What borrowing a profile costs
+
+A profile matches functions by name plus a hash of their code. Functions that exist in Electron but not Chrome (all of Node.js, all of Electron's own C++, `contextBridge`) were never in Chrome's profile. Functions that exist in both but are compiled differently in Electron (different patches, flags, V8 configuration) match by name but fail the hash check and are **silently rejected**. Either way, the compiler gets no guidance and lays the code out as cold.
+
+We measured it with `llvm-profdata`: **about a quarter of the code Electron executes gets zero optimization guidance**, and it's concentrated in exactly the code that makes Electron _Electron_.
+
+<div>
+  <ThemedImage alt="What Chrome's profile knows about Electron's code: 74.5% is optimized (name and hash match), 19.3% is silently rejected (same name, different code: Skia SIMD kernels, V8's JSON stringifier, Mojo, net), and 6.2% is not in Chrome's profile at all (all of Node.js, contextBridge, Electron's own C++). One quarter of the code Electron executes gets zero optimization guidance." sources={{ light: '/assets/img/blog/pgo-coverage-light.svg', dark: '/assets/img/blog/pgo-coverage-dark.svg' }} />
+</div>
+
+This isn't theoretical. While doing this work we found that `crypto.randomBytes` in Electron 44 runs at **less than half** its Electron 42 speed. Nobody touched the crypto code: a BoringSSL patch changed the functions' hashes, Chrome's profile silently stopped covering them, and the compiler started treating them as cold. That's what makes a borrowed profile insidious: code gets slower without anyone changing it, and nothing warns you. With an Electron profile, the regression disappears.
+
+### Fix one: turn on link-time optimization
+
+Chromium links with **ThinLTO**, which lets the compiler optimize across source files at link time, but the default setting does no optimization at all (`--lto-O0`). Chrome's release builds opt into `--lto-O2`. Electron never did.
+
+Opting in is worth about **+5%** on Speedometer 3.1 on an M5 MacBook (and more on older hardware). Useful, but as it turns out, the smaller half of the story.
+
+### Fix two: Electron's own profiles
+
+If borrowing Chrome's profile is the problem, the fix is to train our own: instrumented builds for every release platform, training workloads that exercise Electron the way apps actually use it, and a pipeline that publishes the profiles for release builds to consume.
+
+The training workloads turn out to be the entire game, because PGO is symmetric: everything the training runs gets optimized, and everything it _doesn't_ run gets explicitly laid out as cold. Our first profile was trained on browser benchmarks. Browser-style code got faster, and Node.js `Buffer` operations got **63% slower than stock**, because the training never ran Node.
+
+<div>
+  <ThemedImage alt="The cold-marking trap. A profile trained only on browser benchmarks: browser-style code gets 13% faster, but Node.js Buffer operations get 63% slower than stock because the training never ran Node and the profile marked it cold. The enriched profile, trained on Node.js, contextBridge, IPC, TLS networking, and ASAR module loading as well as browser workloads, keeps the browser wins and fully recovers Node." sources={{ light: '/assets/img/blog/cold-marking-light.svg', dark: '/assets/img/blog/cold-marking-dark.svg' }} />
+</div>
+
+The training suite now covers what Electron apps actually do: main-process Node.js, `contextBridge` and IPC marshaling, networking over real TLS, module loading from ASAR archives, and compression. It also covers V8's **builtins**, which have their own separate profile; Chrome's version rejects every promise and async builtin in Electron (we build V8 with promise hooks enabled, Chrome doesn't), so those were running unoptimized too.
+
+### The results
+
+Each layer stacks on the last. On Speedometer 3.1, on an M5 MacBook:
+
+| Configuration              | Score    | Step     |
+| -------------------------- | -------- | -------- |
+| Stock Electron             | 56.6     |          |
+| + ThinLTO `--lto-O2`       | 59.2     | +5%      |
+| + Electron C++ PGO         | 65.5     | **+11%** |
+| + Electron V8 builtins PGO | **66.2** | +1%      |
+
+That's **+17% end to end**, and the biggest single step is Electron's own profile, not the compiler flag. The borrowed optimization data really was the main problem.
+
+<div>
+  <ThemedImage alt="Speedometer 3.1 on an M5 MacBook as each layer is added: stock Electron 56.6, plus ThinLTO 59.2 (+5%), plus Electron's C++ PGO 65.5 (+11%, the largest step), plus Electron's V8 builtins PGO 66.2. Total +17%, and the biggest gain comes from replacing Chrome's borrowed profile with Electron's own." sources={{ light: '/assets/img/blog/speedometer-stack-light.svg', dark: '/assets/img/blog/speedometer-stack-dark.svg' }} />
+</div>
+
+We also validated the whole stack against the official nightly across a 38-test suite covering `contextBridge`, IPC, and networking, with statistical significance testing:
+
+**37 significant improvements, zero regressions, one tie.**
+
+| Area                                     | Improvement (geomean) |
+| ---------------------------------------- | --------------------- |
+| `contextBridge`                          | **+28%**              |
+| Networking (`fetch`, WebSocket, `https`) | **+19%**              |
+| IPC                                      | **+11%**              |
+| Overall                                  | **+19.5%**            |
+
+The wins land exactly where Electron's own code runs: `contextBridge` calls that round-trip objects are up 40-55%, `fetch` round-trips are up 23-40%, IPC payloads of every size are up 7-16%. On identical workloads, an optimized Electron now matches or exceeds Chrome itself; the penalty for being "Chrome plus Node.js" instead of Chrome is gone.
+
+### What this means for your app
+
+The same app, on the same hardware, spends less CPU doing what it already does. Chat apps: channel switching and message rendering cost 16-20% less CPU, and every preload API call is 28-50% cheaper. Editors: module loading from ASAR is 8-10% faster and `Buffer`-heavy work is no longer pessimized. Document apps: JSON and structured clone of cached data are 13-37% faster.
+
+A useful frame: a UI interaction that costs 19.7 ms today misses the 60 fps frame budget and feels janky. At ~19.5% less CPU it costs about 16.4 ms, inside the budget. These changes move real interactions across that line.
+
+<div>
+  <ThemedImage alt="The 60 fps frame budget is 16.7 ms. Before: an interaction costing 19.7 ms misses the budget and the app drops a frame. After, at about 19.5% less CPU: the same interaction costs about 16.4 ms, inside the budget, and the app stays smooth." sources={{ light: '/assets/img/blog/frame-budget-light.svg', dark: '/assets/img/blog/frame-budget-dark.svg' }} />
+</div>
+
+## Putting it together
+
+- **Startup**: sandboxed renderers start ~43% faster, framework JavaScript comes from an embedded code cache, and the browser process restores its Node.js bootstrap from a snapshot.
+- **Everything after**: Electron stopped borrowing Chrome's compiler optimization data and started generating its own, removing a silent ~20-25% CPU penalty on its hottest code paths.
+
+Apps don't need to do anything except update.
+
+If this kind of work sounds fun, the [Electron repository](https://github.com/electron/electron) is always looking for contributors.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -264,9 +264,22 @@ const config: Config = {
       indexName: 'electronjs',
       contextualSearch: true,
     },
+    // Lightbox (click-to-zoom) for blog post images.
+    // Images wrapped in links are excluded so they navigate instead of zooming.
+    zoom: {
+      selector: '.blog-wrapper .markdown :not(a) > img',
+      background: {
+        light: 'rgba(255, 255, 255, 0.95)',
+        dark: 'rgba(27, 28, 38, 0.95)',
+      },
+      config: {
+        margin: 24,
+      },
+    },
   } satisfies Preset.ThemeConfig,
   plugins: [
     'docusaurus-plugin-sass',
+    'docusaurus-plugin-image-zoom',
     path.resolve(__dirname, './src/plugins/apps/index.ts'),
     path.resolve(__dirname, './src/plugins/releases/index.ts'),
     path.resolve(__dirname, './src/plugins/fiddle/index.ts'),

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "adm-zip": "^0.5.14",
     "ajv": "^8.18.0",
     "clsx": "^1.1.1",
+    "docusaurus-plugin-image-zoom": "^3.0.1",
     "docusaurus-plugin-sass": "^0.2.1",
     "lucide-react": "^0.511.0",
     "prism-react-renderer": "^2.3.1",

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -330,3 +330,18 @@ html {
     }
   }
 }
+
+// Give the blog post table of contents a bit more room. By default it's a
+// `col--2` (~190px in the 1140px container), which wraps almost every
+// heading; widen it to 20% and take the difference from the post column.
+// Scoped by structure: only the blog layout has a `main.col--7` followed by
+// a `.col--2` TOC in the same row (docs use different column classes).
+.main-wrapper .row {
+  main.col.col--7 {
+    --ifm-col-width: 55%;
+  }
+
+  main.col.col--7 ~ .col.col--2 {
+    --ifm-col-width: 20%;
+  }
+}

--- a/static/assets/img/blog/code-cache-flow-dark.svg
+++ b/static/assets/img/blog/code-cache-flow-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 460" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="How the build-time code cache works. At build time, Electron's framework JavaScript is compiled once per process flavor, producing five caches: sandbox, renderer, browser, utility, and worker, each keyed to that process type's V8 flags. At runtime, each process deserializes the cache that matches its own flags. A mismatched cache is silently rejected and V8 falls back to compiling from source.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 460" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="How the build-time code cache works. At build time, Electron's framework JavaScript is compiled once per process flavor, producing five caches: sandbox, renderer, main, utility, and worker, each keyed to that process type's V8 flags. At runtime, each process deserializes the cache that matches its own flags. A mismatched cache is silently rejected and V8 falls back to compiling from source.">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#161b22"/><stop offset="1" stop-color="#0d1117"/></linearGradient>
   </defs>
@@ -41,7 +41,7 @@
     <text x="274" y="218" fill="#8b949e" font-size="10.5" text-anchor="middle">+Node env flags</text>
 
     <rect x="364" y="176" width="152" height="56" rx="8" fill="#193a2e" stroke="#3fb950"/>
-    <text x="440" y="199" fill="#56d364" font-size="13" font-weight="700" text-anchor="middle">browser</text>
+    <text x="440" y="199" fill="#56d364" font-size="13" font-weight="700" text-anchor="middle">main</text>
     <text x="440" y="218" fill="#8b949e" font-size="10.5" text-anchor="middle">main-process flags</text>
 
     <rect x="530" y="176" width="152" height="56" rx="8" fill="#3a2c14" stroke="#d29922"/>
@@ -71,8 +71,8 @@
   <text x="150" y="353" fill="#9feaf9" font-size="11.5" text-anchor="middle">deserializes the sandbox cache</text>
 
   <rect x="322" y="308" width="236" height="62" rx="8" fill="#21262d" stroke="#3fb950"/>
-  <text x="440" y="333" fill="#e6edf3" font-size="13.5" font-weight="600" text-anchor="middle">browser process</text>
-  <text x="440" y="353" fill="#56d364" font-size="11.5" text-anchor="middle">deserializes the browser cache</text>
+  <text x="440" y="333" fill="#e6edf3" font-size="13.5" font-weight="600" text-anchor="middle">main process</text>
+  <text x="440" y="353" fill="#56d364" font-size="11.5" text-anchor="middle">deserializes the main cache</text>
 
   <rect x="612" y="308" width="236" height="62" rx="8" fill="#21262d" stroke="#d29922"/>
   <text x="730" y="333" fill="#e6edf3" font-size="13.5" font-weight="600" text-anchor="middle">utility process</text>

--- a/static/assets/img/blog/code-cache-flow-dark.svg
+++ b/static/assets/img/blog/code-cache-flow-dark.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 460" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="How the build-time code cache works. At build time, Electron's framework JavaScript is compiled once per process flavor, producing five caches: sandbox, renderer, browser, utility, and worker, each keyed to that process type's V8 flags. At runtime, each process deserializes the cache that matches its own flags. A mismatched cache is silently rejected and V8 falls back to compiling from source.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#161b22"/><stop offset="1" stop-color="#0d1117"/></linearGradient>
+  </defs>
+  <rect width="880" height="460" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="459" rx="16" fill="none" stroke="#30363d"/>
+
+  <text x="32" y="44" fill="#e6edf3" font-size="18" font-weight="700">One code cache per process flavor</text>
+
+  <!-- BUILD TIME band -->
+  <text x="32" y="80" fill="#6e7681" font-size="11.5" font-weight="700" letter-spacing="0.12em">BUILD TIME</text>
+  <line x1="125" y1="76" x2="848" y2="76" stroke="#21262d"/>
+
+  <!-- source box -->
+  <rect x="32" y="94" width="240" height="46" rx="8" fill="#21262d" stroke="#30363d"/>
+  <text x="152" y="114" fill="#e6edf3" font-size="13.5" font-weight="600" text-anchor="middle">Electron framework JS</text>
+  <text x="152" y="132" fill="#8b949e" font-size="11.5" text-anchor="middle">embedded in the binary as source</text>
+
+  <!-- generator box -->
+  <rect x="328" y="94" width="220" height="46" rx="8" fill="#21262d" stroke="#30363d"/>
+  <text x="438" y="114" fill="#e6edf3" font-size="13.5" font-weight="600" text-anchor="middle">compiled at build time</text>
+  <text x="438" y="132" fill="#8b949e" font-size="11.5" text-anchor="middle">once per process flavor</text>
+
+  <!-- arrow source -> generator -->
+  <line x1="272" y1="117" x2="320" y2="117" stroke="#8b949e" stroke-width="1.5"/>
+  <path d="M 320 117 l -8 -4 l 0 8 z" fill="#8b949e"/>
+
+  <!-- arrows generator -> caches -->
+  <line x1="438" y1="140" x2="438" y2="166" stroke="#8b949e" stroke-width="1.5"/>
+  <path d="M 438 166 l -4 -8 l 8 0 z" fill="#8b949e"/>
+
+  <!-- 5 flavor cache chips -->
+  <!-- widths: 5 chips across 816px with gaps: chip w=152, gap=14 -->
+  <g>
+    <rect x="32"  y="176" width="152" height="56" rx="8" fill="#0d2a3d" stroke="#2dd4bf"/>
+    <text x="108" y="199" fill="#9feaf9" font-size="13" font-weight="700" text-anchor="middle">sandbox</text>
+    <text x="108" y="218" fill="#8b949e" font-size="10.5" text-anchor="middle">no Node env flags</text>
+
+    <rect x="198" y="176" width="152" height="56" rx="8" fill="#1c2440" stroke="#7c93f9"/>
+    <text x="274" y="199" fill="#a9b9ff" font-size="13" font-weight="700" text-anchor="middle">renderer</text>
+    <text x="274" y="218" fill="#8b949e" font-size="10.5" text-anchor="middle">+Node env flags</text>
+
+    <rect x="364" y="176" width="152" height="56" rx="8" fill="#193a2e" stroke="#3fb950"/>
+    <text x="440" y="199" fill="#56d364" font-size="13" font-weight="700" text-anchor="middle">browser</text>
+    <text x="440" y="218" fill="#8b949e" font-size="10.5" text-anchor="middle">main-process flags</text>
+
+    <rect x="530" y="176" width="152" height="56" rx="8" fill="#3a2c14" stroke="#d29922"/>
+    <text x="606" y="199" fill="#e3b341" font-size="13" font-weight="700" text-anchor="middle">utility</text>
+    <text x="606" y="218" fill="#8b949e" font-size="10.5" text-anchor="middle">utility-process flags</text>
+
+    <rect x="696" y="176" width="152" height="56" rx="8" fill="#21262d" stroke="#8b949e"/>
+    <text x="772" y="199" fill="#c9d1d9" font-size="13" font-weight="700" text-anchor="middle">worker</text>
+    <text x="772" y="218" fill="#8b949e" font-size="10.5" text-anchor="middle">worker flags</text>
+  </g>
+
+  <!-- RUNTIME band -->
+  <text x="32" y="282" fill="#6e7681" font-size="11.5" font-weight="700" letter-spacing="0.12em">RUNTIME</text>
+  <line x1="110" y1="278" x2="848" y2="278" stroke="#21262d"/>
+
+  <!-- matching arrows (3 examples), keyed by color -->
+  <line x1="108" y1="232" x2="108" y2="300" stroke="#2dd4bf" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <path d="M 108 300 l -4 -8 l 8 0 z" fill="#2dd4bf"/>
+  <line x1="440" y1="232" x2="440" y2="300" stroke="#3fb950" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <path d="M 440 300 l -4 -8 l 8 0 z" fill="#3fb950"/>
+  <line x1="606" y1="232" x2="606" y2="300" stroke="#d29922" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <path d="M 606 300 l -4 -8 l 8 0 z" fill="#d29922"/>
+
+  <!-- process boxes -->
+  <rect x="32" y="308" width="236" height="62" rx="8" fill="#21262d" stroke="#2dd4bf"/>
+  <text x="150" y="333" fill="#e6edf3" font-size="13.5" font-weight="600" text-anchor="middle">sandboxed renderer</text>
+  <text x="150" y="353" fill="#9feaf9" font-size="11.5" text-anchor="middle">deserializes the sandbox cache</text>
+
+  <rect x="322" y="308" width="236" height="62" rx="8" fill="#21262d" stroke="#3fb950"/>
+  <text x="440" y="333" fill="#e6edf3" font-size="13.5" font-weight="600" text-anchor="middle">browser process</text>
+  <text x="440" y="353" fill="#56d364" font-size="11.5" text-anchor="middle">deserializes the browser cache</text>
+
+  <rect x="612" y="308" width="236" height="62" rx="8" fill="#21262d" stroke="#d29922"/>
+  <text x="730" y="333" fill="#e6edf3" font-size="13.5" font-weight="600" text-anchor="middle">utility process</text>
+  <text x="730" y="353" fill="#e3b341" font-size="11.5" text-anchor="middle">deserializes the utility cache</text>
+
+  <!-- failure-mode note -->
+  <text x="32" y="408" fill="#8b949e" font-size="12.5">Each process's V8 flags are part of the cache key. The right match deserializes instantly;</text>
+  <text x="32" y="427" fill="#8b949e" font-size="12.5">a mismatch is <tspan fill="#ff7b72" font-weight="600">silently rejected</tspan> and V8 falls back to compiling from source. That's why one cache can't serve every process.</text>
+</svg>

--- a/static/assets/img/blog/code-cache-flow-light.svg
+++ b/static/assets/img/blog/code-cache-flow-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 460" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="How the build-time code cache works. At build time, Electron's framework JavaScript is compiled once per process flavor, producing five caches: sandbox, renderer, browser, utility, and worker, each keyed to that process type's V8 flags. At runtime, each process deserializes the cache that matches its own flags. A mismatched cache is silently rejected and V8 falls back to compiling from source.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 460" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="How the build-time code cache works. At build time, Electron's framework JavaScript is compiled once per process flavor, producing five caches: sandbox, renderer, main, utility, and worker, each keyed to that process type's V8 flags. At runtime, each process deserializes the cache that matches its own flags. A mismatched cache is silently rejected and V8 falls back to compiling from source.">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f6f8fa"/></linearGradient>
   </defs>
@@ -41,7 +41,7 @@
     <text x="274" y="218" fill="#57606a" font-size="10.5" text-anchor="middle">+Node env flags</text>
 
     <rect x="364" y="176" width="152" height="56" rx="8" fill="#dafbe1" stroke="#1a7f37"/>
-    <text x="440" y="199" fill="#1a7f37" font-size="13" font-weight="700" text-anchor="middle">browser</text>
+    <text x="440" y="199" fill="#1a7f37" font-size="13" font-weight="700" text-anchor="middle">main</text>
     <text x="440" y="218" fill="#57606a" font-size="10.5" text-anchor="middle">main-process flags</text>
 
     <rect x="530" y="176" width="152" height="56" rx="8" fill="#fff8c5" stroke="#9a6700"/>
@@ -71,8 +71,8 @@
   <text x="150" y="353" fill="#0a7ea4" font-size="11.5" text-anchor="middle">deserializes the sandbox cache</text>
 
   <rect x="322" y="308" width="236" height="62" rx="8" fill="#eaeef2" stroke="#1a7f37"/>
-  <text x="440" y="333" fill="#1f2328" font-size="13.5" font-weight="600" text-anchor="middle">browser process</text>
-  <text x="440" y="353" fill="#1a7f37" font-size="11.5" text-anchor="middle">deserializes the browser cache</text>
+  <text x="440" y="333" fill="#1f2328" font-size="13.5" font-weight="600" text-anchor="middle">main process</text>
+  <text x="440" y="353" fill="#1a7f37" font-size="11.5" text-anchor="middle">deserializes the main cache</text>
 
   <rect x="612" y="308" width="236" height="62" rx="8" fill="#eaeef2" stroke="#9a6700"/>
   <text x="730" y="333" fill="#1f2328" font-size="13.5" font-weight="600" text-anchor="middle">utility process</text>

--- a/static/assets/img/blog/code-cache-flow-light.svg
+++ b/static/assets/img/blog/code-cache-flow-light.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 460" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="How the build-time code cache works. At build time, Electron's framework JavaScript is compiled once per process flavor, producing five caches: sandbox, renderer, browser, utility, and worker, each keyed to that process type's V8 flags. At runtime, each process deserializes the cache that matches its own flags. A mismatched cache is silently rejected and V8 falls back to compiling from source.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f6f8fa"/></linearGradient>
+  </defs>
+  <rect width="880" height="460" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="459" rx="16" fill="none" stroke="#d0d7de"/>
+
+  <text x="32" y="44" fill="#1f2328" font-size="18" font-weight="700">One code cache per process flavor</text>
+
+  <!-- BUILD TIME band -->
+  <text x="32" y="80" fill="#8c959f" font-size="11.5" font-weight="700" letter-spacing="0.12em">BUILD TIME</text>
+  <line x1="125" y1="76" x2="848" y2="76" stroke="#d8dee4"/>
+
+  <!-- source box -->
+  <rect x="32" y="94" width="240" height="46" rx="8" fill="#eaeef2" stroke="#d0d7de"/>
+  <text x="152" y="114" fill="#1f2328" font-size="13.5" font-weight="600" text-anchor="middle">Electron framework JS</text>
+  <text x="152" y="132" fill="#57606a" font-size="11.5" text-anchor="middle">embedded in the binary as source</text>
+
+  <!-- generator box -->
+  <rect x="328" y="94" width="220" height="46" rx="8" fill="#eaeef2" stroke="#d0d7de"/>
+  <text x="438" y="114" fill="#1f2328" font-size="13.5" font-weight="600" text-anchor="middle">compiled at build time</text>
+  <text x="438" y="132" fill="#57606a" font-size="11.5" text-anchor="middle">once per process flavor</text>
+
+  <!-- arrow source -> generator -->
+  <line x1="272" y1="117" x2="320" y2="117" stroke="#57606a" stroke-width="1.5"/>
+  <path d="M 320 117 l -8 -4 l 0 8 z" fill="#57606a"/>
+
+  <!-- arrows generator -> caches -->
+  <line x1="438" y1="140" x2="438" y2="166" stroke="#57606a" stroke-width="1.5"/>
+  <path d="M 438 166 l -4 -8 l 8 0 z" fill="#57606a"/>
+
+  <!-- 5 flavor cache chips -->
+  <!-- widths: 5 chips across 816px with gaps: chip w=152, gap=14 -->
+  <g>
+    <rect x="32"  y="176" width="152" height="56" rx="8" fill="#ddf4ff" stroke="#0a7ea4"/>
+    <text x="108" y="199" fill="#0a7ea4" font-size="13" font-weight="700" text-anchor="middle">sandbox</text>
+    <text x="108" y="218" fill="#57606a" font-size="10.5" text-anchor="middle">no Node env flags</text>
+
+    <rect x="198" y="176" width="152" height="56" rx="8" fill="#e7e9fb" stroke="#4b59c7"/>
+    <text x="274" y="199" fill="#4b59c7" font-size="13" font-weight="700" text-anchor="middle">renderer</text>
+    <text x="274" y="218" fill="#57606a" font-size="10.5" text-anchor="middle">+Node env flags</text>
+
+    <rect x="364" y="176" width="152" height="56" rx="8" fill="#dafbe1" stroke="#1a7f37"/>
+    <text x="440" y="199" fill="#1a7f37" font-size="13" font-weight="700" text-anchor="middle">browser</text>
+    <text x="440" y="218" fill="#57606a" font-size="10.5" text-anchor="middle">main-process flags</text>
+
+    <rect x="530" y="176" width="152" height="56" rx="8" fill="#fff8c5" stroke="#9a6700"/>
+    <text x="606" y="199" fill="#9a6700" font-size="13" font-weight="700" text-anchor="middle">utility</text>
+    <text x="606" y="218" fill="#57606a" font-size="10.5" text-anchor="middle">utility-process flags</text>
+
+    <rect x="696" y="176" width="152" height="56" rx="8" fill="#eaeef2" stroke="#57606a"/>
+    <text x="772" y="199" fill="#1f2328" font-size="13" font-weight="700" text-anchor="middle">worker</text>
+    <text x="772" y="218" fill="#57606a" font-size="10.5" text-anchor="middle">worker flags</text>
+  </g>
+
+  <!-- RUNTIME band -->
+  <text x="32" y="282" fill="#8c959f" font-size="11.5" font-weight="700" letter-spacing="0.12em">RUNTIME</text>
+  <line x1="110" y1="278" x2="848" y2="278" stroke="#d8dee4"/>
+
+  <!-- matching arrows (3 examples), keyed by color -->
+  <line x1="108" y1="232" x2="108" y2="300" stroke="#0a7ea4" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <path d="M 108 300 l -4 -8 l 8 0 z" fill="#0a7ea4"/>
+  <line x1="440" y1="232" x2="440" y2="300" stroke="#1a7f37" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <path d="M 440 300 l -4 -8 l 8 0 z" fill="#1a7f37"/>
+  <line x1="606" y1="232" x2="606" y2="300" stroke="#9a6700" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <path d="M 606 300 l -4 -8 l 8 0 z" fill="#9a6700"/>
+
+  <!-- process boxes -->
+  <rect x="32" y="308" width="236" height="62" rx="8" fill="#eaeef2" stroke="#0a7ea4"/>
+  <text x="150" y="333" fill="#1f2328" font-size="13.5" font-weight="600" text-anchor="middle">sandboxed renderer</text>
+  <text x="150" y="353" fill="#0a7ea4" font-size="11.5" text-anchor="middle">deserializes the sandbox cache</text>
+
+  <rect x="322" y="308" width="236" height="62" rx="8" fill="#eaeef2" stroke="#1a7f37"/>
+  <text x="440" y="333" fill="#1f2328" font-size="13.5" font-weight="600" text-anchor="middle">browser process</text>
+  <text x="440" y="353" fill="#1a7f37" font-size="11.5" text-anchor="middle">deserializes the browser cache</text>
+
+  <rect x="612" y="308" width="236" height="62" rx="8" fill="#eaeef2" stroke="#9a6700"/>
+  <text x="730" y="333" fill="#1f2328" font-size="13.5" font-weight="600" text-anchor="middle">utility process</text>
+  <text x="730" y="353" fill="#9a6700" font-size="11.5" text-anchor="middle">deserializes the utility cache</text>
+
+  <!-- failure-mode note -->
+  <text x="32" y="408" fill="#57606a" font-size="12.5">Each process's V8 flags are part of the cache key. The right match deserializes instantly;</text>
+  <text x="32" y="427" fill="#57606a" font-size="12.5">a mismatch is <tspan fill="#cf222e" font-weight="600">silently rejected</tspan> and V8 falls back to compiling from source. That's why one cache can't serve every process.</text>
+</svg>

--- a/static/assets/img/blog/cold-marking-dark.svg
+++ b/static/assets/img/blog/cold-marking-dark.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="The cold-marking trap. A profile trained only on browser benchmarks made browser-style code faster (Speedometer up 13%) but made Node.js Buffer operations 63% slower than stock, because the training never ran Node so the profile marked all of it cold. The enriched training profile, which adds Node.js, contextBridge and IPC, real-TLS networking, and ASAR module loading, keeps the browser wins and recovers Node fully.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#161b22"/><stop offset="1" stop-color="#0d1117"/></linearGradient>
+  </defs>
+  <rect width="880" height="420" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="419" rx="16" fill="none" stroke="#30363d"/>
+
+  <text x="32" y="44" fill="#e6edf3" font-size="18" font-weight="700">PGO is symmetric: what you don't train gets pessimized</text>
+  <text x="32" y="68" fill="#8b949e" font-size="13">The same optimized build, measured with two different training profiles</text>
+
+  <line x1="440" y1="92" x2="440" y2="356" stroke="#30363d"/>
+
+  <!-- ============ LEFT: v1 benchmark-only ============ -->
+  <text x="32" y="112" fill="#f0883e" font-size="13" font-weight="700" letter-spacing="0.06em">TRAINED ON BROWSER BENCHMARKS ONLY</text>
+
+  <!-- what it ran -->
+  <text x="32" y="140" fill="#8b949e" font-size="12">Training ran:</text>
+  <rect x="120" y="126" width="110" height="22" rx="11" fill="#21262d" stroke="#30363d"/>
+  <text x="175" y="141" fill="#c9d1d9" font-size="11.5" text-anchor="middle">Speedometer</text>
+  <rect x="236" y="126" width="80" height="22" rx="11" fill="#21262d" stroke="#30363d"/>
+  <text x="276" y="141" fill="#c9d1d9" font-size="11.5" text-anchor="middle">DOM, CSS</text>
+
+  <!-- results -->
+  <text x="32" y="186" fill="#c9d1d9" font-size="13" font-weight="600">Browser-style code</text>
+  <rect x="32" y="196" width="180" height="14" rx="7" fill="#2ea043"/>
+  <text x="220" y="208" fill="#56d364" font-size="12.5" font-weight="700">+13% &#10003;</text>
+
+  <text x="32" y="248" fill="#c9d1d9" font-size="13" font-weight="600">Node.js Buffer operations</text>
+  <rect x="32" y="258" width="330" height="14" rx="7" fill="#21262d"/>
+  <rect x="32" y="258" width="122" height="14" rx="7" fill="#da3633"/>
+  <text x="362" y="270" fill="#ff7b72" font-size="12.5" font-weight="700" text-anchor="end">&#8722;63% &#10007;</text>
+
+  <rect x="32" y="296" width="376" height="60" rx="8" fill="#3d1d1d" stroke="#da3633"/>
+  <text x="50" y="321" fill="#ff7b72" font-size="12.5" font-weight="700">Never ran Node, so the profile marked</text>
+  <text x="50" y="340" fill="#ff7b72" font-size="12.5" font-weight="700">all of Node cold. Worse than no profile.</text>
+
+  <!-- ============ RIGHT: enriched training ============ -->
+  <text x="472" y="112" fill="#3fb950" font-size="13" font-weight="700" letter-spacing="0.06em">TRAINED ON HOW APPS USE ELECTRON</text>
+
+  <text x="472" y="140" fill="#8b949e" font-size="12">Training ran:</text>
+  <rect x="560" y="126" width="110" height="22" rx="11" fill="#21262d" stroke="#30363d"/>
+  <text x="615" y="141" fill="#c9d1d9" font-size="11.5" text-anchor="middle">Speedometer</text>
+  <rect x="676" y="126" width="62" height="22" rx="11" fill="#193a2e" stroke="#3fb950"/>
+  <text x="707" y="141" fill="#56d364" font-size="11.5" text-anchor="middle">Node.js</text>
+  <rect x="744" y="126" width="104" height="22" rx="11" fill="#193a2e" stroke="#3fb950"/>
+  <text x="796" y="141" fill="#56d364" font-size="11.5" text-anchor="middle">contextBridge</text>
+  <rect x="560" y="152" width="56" height="22" rx="11" fill="#193a2e" stroke="#3fb950"/>
+  <text x="588" y="167" fill="#56d364" font-size="11.5" text-anchor="middle">IPC</text>
+  <rect x="622" y="152" width="56" height="22" rx="11" fill="#193a2e" stroke="#3fb950"/>
+  <text x="650" y="167" fill="#56d364" font-size="11.5" text-anchor="middle">TLS</text>
+  <rect x="684" y="152" width="120" height="22" rx="11" fill="#193a2e" stroke="#3fb950"/>
+  <text x="744" y="167" fill="#56d364" font-size="11.5" text-anchor="middle">ASAR + modules</text>
+
+  <!-- results -->
+  <text x="472" y="210" fill="#c9d1d9" font-size="13" font-weight="600">Browser-style code</text>
+  <rect x="472" y="220" width="180" height="14" rx="7" fill="#2ea043"/>
+  <text x="660" y="232" fill="#56d364" font-size="12.5" font-weight="700">+13% kept &#10003;</text>
+
+  <text x="472" y="262" fill="#c9d1d9" font-size="13" font-weight="600">Node.js Buffer operations</text>
+  <rect x="472" y="272" width="186" height="14" rx="7" fill="#2ea043"/>
+  <text x="666" y="284" fill="#56d364" font-size="12.5" font-weight="700">recovered &#10003;</text>
+
+  <rect x="472" y="296" width="376" height="60" rx="8" fill="#193a2e" stroke="#3fb950"/>
+  <text x="490" y="321" fill="#56d364" font-size="12.5" font-weight="700">Training breadth is the whole game:</text>
+  <text x="490" y="340" fill="#56d364" font-size="12.5" font-weight="700">profile what apps actually do, not benchmarks.</text>
+
+  <text x="32" y="396" fill="#6e7681" font-size="11">Buffer regression measured on macOS arm64; Speedometer on Linux x64. Both profiles applied to identical source.</text>
+</svg>

--- a/static/assets/img/blog/cold-marking-light.svg
+++ b/static/assets/img/blog/cold-marking-light.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="The cold-marking trap. A profile trained only on browser benchmarks made browser-style code faster (Speedometer up 13%) but made Node.js Buffer operations 63% slower than stock, because the training never ran Node so the profile marked all of it cold. The enriched training profile, which adds Node.js, contextBridge and IPC, real-TLS networking, and ASAR module loading, keeps the browser wins and recovers Node fully.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f6f8fa"/></linearGradient>
+  </defs>
+  <rect width="880" height="420" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="419" rx="16" fill="none" stroke="#d0d7de"/>
+
+  <text x="32" y="44" fill="#1f2328" font-size="18" font-weight="700">PGO is symmetric: what you don't train gets pessimized</text>
+  <text x="32" y="68" fill="#57606a" font-size="13">The same optimized build, measured with two different training profiles</text>
+
+  <line x1="440" y1="92" x2="440" y2="356" stroke="#d0d7de"/>
+
+  <!-- ============ LEFT: v1 benchmark-only ============ -->
+  <text x="32" y="112" fill="#bc4c00" font-size="13" font-weight="700" letter-spacing="0.06em">TRAINED ON BROWSER BENCHMARKS ONLY</text>
+
+  <!-- what it ran -->
+  <text x="32" y="140" fill="#57606a" font-size="12">Training ran:</text>
+  <rect x="120" y="126" width="110" height="22" rx="11" fill="#eaeef2" stroke="#d0d7de"/>
+  <text x="175" y="141" fill="#1f2328" font-size="11.5" text-anchor="middle">Speedometer</text>
+  <rect x="236" y="126" width="80" height="22" rx="11" fill="#eaeef2" stroke="#d0d7de"/>
+  <text x="276" y="141" fill="#1f2328" font-size="11.5" text-anchor="middle">DOM, CSS</text>
+
+  <!-- results -->
+  <text x="32" y="186" fill="#1f2328" font-size="13" font-weight="600">Browser-style code</text>
+  <rect x="32" y="196" width="180" height="14" rx="7" fill="#2da44e"/>
+  <text x="220" y="208" fill="#1a7f37" font-size="12.5" font-weight="700">+13% &#10003;</text>
+
+  <text x="32" y="248" fill="#1f2328" font-size="13" font-weight="600">Node.js Buffer operations</text>
+  <rect x="32" y="258" width="330" height="14" rx="7" fill="#eaeef2"/>
+  <rect x="32" y="258" width="122" height="14" rx="7" fill="#cf222e"/>
+  <text x="362" y="270" fill="#cf222e" font-size="12.5" font-weight="700" text-anchor="end">&#8722;63% &#10007;</text>
+
+  <rect x="32" y="296" width="376" height="60" rx="8" fill="#ffebe9" stroke="#cf222e"/>
+  <text x="50" y="321" fill="#cf222e" font-size="12.5" font-weight="700">Never ran Node, so the profile marked</text>
+  <text x="50" y="340" fill="#cf222e" font-size="12.5" font-weight="700">all of Node cold. Worse than no profile.</text>
+
+  <!-- ============ RIGHT: enriched training ============ -->
+  <text x="472" y="112" fill="#1a7f37" font-size="13" font-weight="700" letter-spacing="0.06em">TRAINED ON HOW APPS USE ELECTRON</text>
+
+  <text x="472" y="140" fill="#57606a" font-size="12">Training ran:</text>
+  <rect x="560" y="126" width="110" height="22" rx="11" fill="#eaeef2" stroke="#d0d7de"/>
+  <text x="615" y="141" fill="#1f2328" font-size="11.5" text-anchor="middle">Speedometer</text>
+  <rect x="676" y="126" width="62" height="22" rx="11" fill="#dafbe1" stroke="#1a7f37"/>
+  <text x="707" y="141" fill="#1a7f37" font-size="11.5" text-anchor="middle">Node.js</text>
+  <rect x="744" y="126" width="104" height="22" rx="11" fill="#dafbe1" stroke="#1a7f37"/>
+  <text x="796" y="141" fill="#1a7f37" font-size="11.5" text-anchor="middle">contextBridge</text>
+  <rect x="560" y="152" width="56" height="22" rx="11" fill="#dafbe1" stroke="#1a7f37"/>
+  <text x="588" y="167" fill="#1a7f37" font-size="11.5" text-anchor="middle">IPC</text>
+  <rect x="622" y="152" width="56" height="22" rx="11" fill="#dafbe1" stroke="#1a7f37"/>
+  <text x="650" y="167" fill="#1a7f37" font-size="11.5" text-anchor="middle">TLS</text>
+  <rect x="684" y="152" width="120" height="22" rx="11" fill="#dafbe1" stroke="#1a7f37"/>
+  <text x="744" y="167" fill="#1a7f37" font-size="11.5" text-anchor="middle">ASAR + modules</text>
+
+  <!-- results -->
+  <text x="472" y="210" fill="#1f2328" font-size="13" font-weight="600">Browser-style code</text>
+  <rect x="472" y="220" width="180" height="14" rx="7" fill="#2da44e"/>
+  <text x="660" y="232" fill="#1a7f37" font-size="12.5" font-weight="700">+13% kept &#10003;</text>
+
+  <text x="472" y="262" fill="#1f2328" font-size="13" font-weight="600">Node.js Buffer operations</text>
+  <rect x="472" y="272" width="186" height="14" rx="7" fill="#2da44e"/>
+  <text x="666" y="284" fill="#1a7f37" font-size="12.5" font-weight="700">recovered &#10003;</text>
+
+  <rect x="472" y="296" width="376" height="60" rx="8" fill="#dafbe1" stroke="#1a7f37"/>
+  <text x="490" y="321" fill="#1a7f37" font-size="12.5" font-weight="700">Training breadth is the whole game:</text>
+  <text x="490" y="340" fill="#1a7f37" font-size="12.5" font-weight="700">profile what apps actually do, not benchmarks.</text>
+
+  <text x="32" y="396" fill="#8c959f" font-size="11">Buffer regression measured on macOS arm64; Speedometer on Linux x64. Both profiles applied to identical source.</text>
+</svg>

--- a/static/assets/img/blog/extend-not-build-dark.svg
+++ b/static/assets/img/blog/extend-not-build-dark.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 320" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Two ways to create a snapshot. Building a heap from scratch needs V8's full setup-isolate delegate, which is linked only into V8's own mksnapshot and is not available to embedders, so that path fails. Extending an existing snapshot loads snapshot_blob.bin as a base and hands it to the SnapshotCreator; this uses the deserialize delegate that Electron already links, and it works.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#161b22"/><stop offset="1" stop-color="#0d1117"/></linearGradient>
+  </defs>
+  <rect width="880" height="320" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="319" rx="16" fill="none" stroke="#30363d"/>
+
+  <text x="32" y="44" fill="#e6edf3" font-size="18" font-weight="700">You don't build a heap, you extend one</text>
+
+  <line x1="440" y1="72" x2="440" y2="296" stroke="#30363d"/>
+
+  <!-- LEFT: build from scratch (fails) -->
+  <text x="32" y="98" fill="#f85149" font-size="13" font-weight="700" letter-spacing="0.06em">BUILD FROM SCRATCH</text>
+  <rect x="32" y="116" width="376" height="40" rx="6" fill="#21262d" stroke="#30363d"/>
+  <text x="52" y="141" fill="#c9d1d9" font-size="13">SnapshotCreator builds the heap + builtins</text>
+  <text x="212" y="178" fill="#6e7681" font-size="18" text-anchor="middle">&#8595;</text>
+  <rect x="32" y="190" width="376" height="40" rx="6" fill="#21262d" stroke="#30363d"/>
+  <text x="52" y="215" fill="#c9d1d9" font-size="13">needs the <tspan font-weight="600">full</tspan> setup-isolate delegate</text>
+  <text x="212" y="252" fill="#6e7681" font-size="18" text-anchor="middle">&#8595;</text>
+  <rect x="32" y="264" width="376" height="36" rx="6" fill="#3d1d1d" stroke="#f85149"/>
+  <text x="52" y="287" fill="#ff7b72" font-size="12.5">linked only into V8's own <tspan font-weight="600">mksnapshot</tspan> &#8212; not for embedders</text>
+
+  <!-- RIGHT: extend (works) -->
+  <text x="464" y="98" fill="#3fb950" font-size="13" font-weight="700" letter-spacing="0.06em">EXTEND AN EXISTING SNAPSHOT</text>
+  <rect x="464" y="116" width="384" height="40" rx="6" fill="#21262d" stroke="#30363d"/>
+  <text x="484" y="141" fill="#c9d1d9" font-size="13">load <tspan font-weight="600">snapshot_blob.bin</tspan> as the base</text>
+  <text x="656" y="178" fill="#6e7681" font-size="18" text-anchor="middle">&#8595;</text>
+  <rect x="464" y="190" width="384" height="40" rx="6" fill="#21262d" stroke="#30363d"/>
+  <text x="484" y="215" fill="#c9d1d9" font-size="13">SnapshotCreator(<tspan font-weight="600">params.snapshot_blob</tspan>)</text>
+  <text x="656" y="252" fill="#6e7681" font-size="18" text-anchor="middle">&#8595;</text>
+  <rect x="464" y="264" width="384" height="36" rx="6" fill="#193a2e" stroke="#3fb950"/>
+  <text x="484" y="287" fill="#56d364" font-size="12.5">uses the <tspan font-weight="600">deserialize</tspan> delegate Electron already links &#10003;</text>
+</svg>

--- a/static/assets/img/blog/extend-not-build-light.svg
+++ b/static/assets/img/blog/extend-not-build-light.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 320" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Two ways to create a snapshot. Building a heap from scratch needs V8's full setup-isolate delegate, which is linked only into V8's own mksnapshot and is not available to embedders, so that path fails. Extending an existing snapshot loads snapshot_blob.bin as a base and hands it to the SnapshotCreator; this uses the deserialize delegate that Electron already links, and it works.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f6f8fa"/></linearGradient>
+  </defs>
+  <rect width="880" height="320" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="319" rx="16" fill="none" stroke="#d0d7de"/>
+
+  <text x="32" y="44" fill="#1f2328" font-size="18" font-weight="700">You don't build a heap, you extend one</text>
+
+  <line x1="440" y1="72" x2="440" y2="296" stroke="#d0d7de"/>
+
+  <!-- LEFT: build from scratch (fails) -->
+  <text x="32" y="98" fill="#cf222e" font-size="13" font-weight="700" letter-spacing="0.06em">BUILD FROM SCRATCH</text>
+  <rect x="32" y="116" width="376" height="40" rx="6" fill="#eaeef2" stroke="#d0d7de"/>
+  <text x="52" y="141" fill="#1f2328" font-size="13">SnapshotCreator builds the heap + builtins</text>
+  <text x="212" y="178" fill="#8c959f" font-size="18" text-anchor="middle">&#8595;</text>
+  <rect x="32" y="190" width="376" height="40" rx="6" fill="#eaeef2" stroke="#d0d7de"/>
+  <text x="52" y="215" fill="#1f2328" font-size="13">needs the <tspan font-weight="600">full</tspan> setup-isolate delegate</text>
+  <text x="212" y="252" fill="#8c959f" font-size="18" text-anchor="middle">&#8595;</text>
+  <rect x="32" y="264" width="376" height="36" rx="6" fill="#ffebe9" stroke="#cf222e"/>
+  <text x="52" y="287" fill="#cf222e" font-size="12.5">linked only into V8's own <tspan font-weight="600">mksnapshot</tspan> &#8212; not for embedders</text>
+
+  <!-- RIGHT: extend (works) -->
+  <text x="464" y="98" fill="#1a7f37" font-size="13" font-weight="700" letter-spacing="0.06em">EXTEND AN EXISTING SNAPSHOT</text>
+  <rect x="464" y="116" width="384" height="40" rx="6" fill="#eaeef2" stroke="#d0d7de"/>
+  <text x="484" y="141" fill="#1f2328" font-size="13">load <tspan font-weight="600">snapshot_blob.bin</tspan> as the base</text>
+  <text x="656" y="178" fill="#8c959f" font-size="18" text-anchor="middle">&#8595;</text>
+  <rect x="464" y="190" width="384" height="40" rx="6" fill="#eaeef2" stroke="#d0d7de"/>
+  <text x="484" y="215" fill="#1f2328" font-size="13">SnapshotCreator(<tspan font-weight="600">params.snapshot_blob</tspan>)</text>
+  <text x="656" y="252" fill="#8c959f" font-size="18" text-anchor="middle">&#8595;</text>
+  <rect x="464" y="264" width="384" height="36" rx="6" fill="#dafbe1" stroke="#1a7f37"/>
+  <text x="484" y="287" fill="#1a7f37" font-size="12.5">uses the <tspan font-weight="600">deserialize</tspan> delegate Electron already links &#10003;</text>
+</svg>

--- a/static/assets/img/blog/faster-startup-hero-dark.svg
+++ b/static/assets/img/blog/faster-startup-hero-dark.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Electron performance improvements. Startup: sandboxed renderer startup drops from about 230 ms to about 130 ms (about 43%); browser-process startup drops from about 125 ms to about 75 ms (about 40%). Runtime: Speedometer 3.1 on an M5 MacBook rises from 56.6 to 66.2 (about 17%); contextBridge calls are about 28% faster overall.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#161b22"/>
+      <stop offset="1" stop-color="#0d1117"/>
+    </linearGradient>
+    <linearGradient id="barA" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#2dd4bf"/><stop offset="1" stop-color="#9feaf9"/>
+    </linearGradient>
+    <linearGradient id="barB" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#7c93f9"/><stop offset="1" stop-color="#a9b9ff"/>
+    </linearGradient>
+    <linearGradient id="barC" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#2ea043"/><stop offset="1" stop-color="#56d364"/>
+    </linearGradient>
+    <linearGradient id="barD" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#d29922"/><stop offset="1" stop-color="#e3b341"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="540" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="959" height="539" rx="16" fill="none" stroke="#30363d"/>
+
+  <text x="40" y="50" fill="#8b949e" font-size="15" font-weight="600" letter-spacing="0.12em">ELECTRON · FASTER, NO API CHANGES</text>
+
+  <!-- ===================== ROW 1: STARTUP ===================== -->
+  <text x="40" y="94" fill="#6e7681" font-size="12" font-weight="700" letter-spacing="0.14em">STARTUP</text>
+  <line x1="122" y1="89" x2="920" y2="89" stroke="#21262d"/>
+
+  <line x1="480" y1="106" x2="480" y2="276" stroke="#30363d"/>
+
+  <!-- Col 1: sandboxed renderer -->
+  <text x="40" y="174" fill="#9feaf9" font-size="58" font-weight="800" letter-spacing="-0.02em">~43%</text>
+  <text x="42" y="204" fill="#e6edf3" font-size="17" font-weight="600">sandboxed renderer startup</text>
+  <text x="42" y="225" fill="#8b949e" font-size="13">preload setup off synchronous IPC<tspan fill="#6e7681"> *</tspan></text>
+  <rect x="42" y="242" width="288" height="10" rx="5" fill="#3d4450"/>
+  <text x="338" y="251" fill="#8b949e" font-size="11.5" font-weight="600">~230 ms</text>
+  <rect x="42" y="262" width="288" height="10" rx="5" fill="#21262d"/>
+  <rect x="42" y="262" width="163" height="10" rx="5" fill="url(#barA)"/>
+  <text x="338" y="271" fill="#9feaf9" font-size="11.5" font-weight="700">~130 ms</text>
+
+  <!-- Col 2: browser process -->
+  <text x="512" y="174" fill="#a9b9ff" font-size="58" font-weight="800" letter-spacing="-0.02em">~40%</text>
+  <text x="514" y="204" fill="#e6edf3" font-size="17" font-weight="600">browser process startup</text>
+  <text x="514" y="225" fill="#8b949e" font-size="13">Node.js bootstrap from a snapshot<tspan fill="#6e7681"> *</tspan></text>
+  <rect x="514" y="242" width="288" height="10" rx="5" fill="#3d4450"/>
+  <text x="810" y="251" fill="#8b949e" font-size="11.5" font-weight="600">~125 ms</text>
+  <rect x="514" y="262" width="288" height="10" rx="5" fill="#21262d"/>
+  <rect x="514" y="262" width="173" height="10" rx="5" fill="url(#barB)"/>
+  <text x="810" y="271" fill="#a9b9ff" font-size="11.5" font-weight="700">~75 ms</text>
+
+  <!-- ===================== ROW 2: RUNTIME ===================== -->
+  <text x="40" y="324" fill="#6e7681" font-size="12" font-weight="700" letter-spacing="0.14em">EVERYTHING AFTER STARTUP</text>
+  <line x1="252" y1="319" x2="920" y2="319" stroke="#21262d"/>
+
+  <line x1="480" y1="336" x2="480" y2="496" stroke="#30363d"/>
+
+  <!-- Col 3: Speedometer -->
+  <text x="40" y="404" fill="#56d364" font-size="58" font-weight="800" letter-spacing="-0.02em">+17%</text>
+  <text x="42" y="434" fill="#e6edf3" font-size="17" font-weight="600">Speedometer 3.1</text>
+  <text x="42" y="455" fill="#8b949e" font-size="13">link-time optimization + Electron PGO<tspan fill="#6e7681"> &#8224;</tspan></text>
+  <rect x="42" y="472" width="288" height="10" rx="5" fill="#21262d"/>
+  <rect x="42" y="472" width="246" height="10" rx="5" fill="#3d4450"/>
+  <text x="338" y="481" fill="#8b949e" font-size="11.5" font-weight="600">56.6</text>
+  <rect x="42" y="492" width="288" height="10" rx="5" fill="#21262d"/>
+  <rect x="42" y="492" width="288" height="10" rx="5" fill="url(#barC)"/>
+  <text x="338" y="501" fill="#56d364" font-size="11.5" font-weight="700">66.2</text>
+
+  <!-- Col 4: contextBridge -->
+  <text x="512" y="404" fill="#e3b341" font-size="58" font-weight="800" letter-spacing="-0.02em">+28%</text>
+  <text x="514" y="434" fill="#e6edf3" font-size="17" font-weight="600">contextBridge calls</text>
+  <text x="514" y="455" fill="#8b949e" font-size="13">optimized with Electron's own profile<tspan fill="#6e7681"> &#8224;</tspan></text>
+  <rect x="514" y="472" width="288" height="10" rx="5" fill="#21262d"/>
+  <rect x="514" y="472" width="225" height="10" rx="5" fill="#3d4450"/>
+  <text x="810" y="481" fill="#8b949e" font-size="11.5" font-weight="600">baseline</text>
+  <rect x="514" y="492" width="288" height="10" rx="5" fill="#21262d"/>
+  <rect x="514" y="492" width="288" height="10" rx="5" fill="url(#barD)"/>
+  <text x="810" y="501" fill="#e3b341" font-size="11.5" font-weight="700">+28%</text>
+
+  <!-- footnotes -->
+  <text x="40" y="530" fill="#6e7681" font-size="10.5">* Sample app, two ~150&#8201;KB preloads, cold launch, Apple Silicon. &#160;&#160;&#8224; Speedometer on MacBook (M5); contextBridge geomean across 13 tests (Linux x64). Numbers vary by hardware.</text>
+</svg>

--- a/static/assets/img/blog/faster-startup-hero-dark.svg
+++ b/static/assets/img/blog/faster-startup-hero-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Electron performance improvements. Startup: sandboxed renderer startup drops from about 230 ms to about 130 ms (about 43%); browser-process startup drops from about 125 ms to about 75 ms (about 40%). Runtime: Speedometer 3.1 on an M5 MacBook rises from 56.6 to 66.2 (about 17%); contextBridge calls are about 28% faster overall.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Electron performance improvements. Startup: sandboxed renderer startup drops from about 230 ms to about 130 ms (about 43%); main-process startup drops from about 125 ms to about 75 ms (about 40%). Runtime: Speedometer 3.1 on an M5 MacBook rises from 56.6 to 66.2 (about 17%); contextBridge calls are about 28% faster overall.">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#161b22"/>
@@ -39,9 +39,9 @@
   <rect x="42" y="262" width="163" height="10" rx="5" fill="url(#barA)"/>
   <text x="338" y="271" fill="#9feaf9" font-size="11.5" font-weight="700">~130 ms</text>
 
-  <!-- Col 2: browser process -->
+  <!-- Col 2: main process -->
   <text x="512" y="174" fill="#a9b9ff" font-size="58" font-weight="800" letter-spacing="-0.02em">~40%</text>
-  <text x="514" y="204" fill="#e6edf3" font-size="17" font-weight="600">browser process startup</text>
+  <text x="514" y="204" fill="#e6edf3" font-size="17" font-weight="600">main process startup</text>
   <text x="514" y="225" fill="#8b949e" font-size="13">Node.js bootstrap from a snapshot<tspan fill="#6e7681"> *</tspan></text>
   <rect x="514" y="242" width="288" height="10" rx="5" fill="#3d4450"/>
   <text x="810" y="251" fill="#8b949e" font-size="11.5" font-weight="600">~125 ms</text>

--- a/static/assets/img/blog/faster-startup-hero-light.svg
+++ b/static/assets/img/blog/faster-startup-hero-light.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Electron performance improvements. Startup: sandboxed renderer startup drops from about 230 ms to about 130 ms (about 43%); browser-process startup drops from about 125 ms to about 75 ms (about 40%). Runtime: Speedometer 3.1 on an M5 MacBook rises from 56.6 to 66.2 (about 17%); contextBridge calls are about 28% faster overall.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#f6f8fa"/>
+    </linearGradient>
+    <linearGradient id="barA" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#0a7ea4"/><stop offset="1" stop-color="#39b8d8"/>
+    </linearGradient>
+    <linearGradient id="barB" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#4b59c7"/><stop offset="1" stop-color="#7385e0"/>
+    </linearGradient>
+    <linearGradient id="barC" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#1a7f37"/><stop offset="1" stop-color="#2da44e"/>
+    </linearGradient>
+    <linearGradient id="barD" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#9a6700"/><stop offset="1" stop-color="#bf8700"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="540" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="959" height="539" rx="16" fill="none" stroke="#d0d7de"/>
+
+  <text x="40" y="50" fill="#57606a" font-size="15" font-weight="600" letter-spacing="0.12em">ELECTRON · FASTER, NO API CHANGES</text>
+
+  <!-- ===================== ROW 1: STARTUP ===================== -->
+  <text x="40" y="94" fill="#8c959f" font-size="12" font-weight="700" letter-spacing="0.14em">STARTUP</text>
+  <line x1="122" y1="89" x2="920" y2="89" stroke="#d8dee4"/>
+
+  <line x1="480" y1="106" x2="480" y2="276" stroke="#d0d7de"/>
+
+  <!-- Col 1: sandboxed renderer -->
+  <text x="40" y="174" fill="#0a7ea4" font-size="58" font-weight="800" letter-spacing="-0.02em">~43%</text>
+  <text x="42" y="204" fill="#1f2328" font-size="17" font-weight="600">sandboxed renderer startup</text>
+  <text x="42" y="225" fill="#57606a" font-size="13">preload setup off synchronous IPC<tspan fill="#8c959f"> *</tspan></text>
+  <rect x="42" y="242" width="288" height="10" rx="5" fill="#afb8c1"/>
+  <text x="338" y="251" fill="#57606a" font-size="11.5" font-weight="600">~230 ms</text>
+  <rect x="42" y="262" width="288" height="10" rx="5" fill="#eaeef2"/>
+  <rect x="42" y="262" width="163" height="10" rx="5" fill="url(#barA)"/>
+  <text x="338" y="271" fill="#0a7ea4" font-size="11.5" font-weight="700">~130 ms</text>
+
+  <!-- Col 2: browser process -->
+  <text x="512" y="174" fill="#4b59c7" font-size="58" font-weight="800" letter-spacing="-0.02em">~40%</text>
+  <text x="514" y="204" fill="#1f2328" font-size="17" font-weight="600">browser process startup</text>
+  <text x="514" y="225" fill="#57606a" font-size="13">Node.js bootstrap from a snapshot<tspan fill="#8c959f"> *</tspan></text>
+  <rect x="514" y="242" width="288" height="10" rx="5" fill="#afb8c1"/>
+  <text x="810" y="251" fill="#57606a" font-size="11.5" font-weight="600">~125 ms</text>
+  <rect x="514" y="262" width="288" height="10" rx="5" fill="#eaeef2"/>
+  <rect x="514" y="262" width="173" height="10" rx="5" fill="url(#barB)"/>
+  <text x="810" y="271" fill="#4b59c7" font-size="11.5" font-weight="700">~75 ms</text>
+
+  <!-- ===================== ROW 2: RUNTIME ===================== -->
+  <text x="40" y="324" fill="#8c959f" font-size="12" font-weight="700" letter-spacing="0.14em">EVERYTHING AFTER STARTUP</text>
+  <line x1="252" y1="319" x2="920" y2="319" stroke="#d8dee4"/>
+
+  <line x1="480" y1="336" x2="480" y2="496" stroke="#d0d7de"/>
+
+  <!-- Col 3: Speedometer -->
+  <text x="40" y="404" fill="#1a7f37" font-size="58" font-weight="800" letter-spacing="-0.02em">+17%</text>
+  <text x="42" y="434" fill="#1f2328" font-size="17" font-weight="600">Speedometer 3.1</text>
+  <text x="42" y="455" fill="#57606a" font-size="13">link-time optimization + Electron PGO<tspan fill="#8c959f"> &#8224;</tspan></text>
+  <rect x="42" y="472" width="288" height="10" rx="5" fill="#eaeef2"/>
+  <rect x="42" y="472" width="246" height="10" rx="5" fill="#afb8c1"/>
+  <text x="338" y="481" fill="#57606a" font-size="11.5" font-weight="600">56.6</text>
+  <rect x="42" y="492" width="288" height="10" rx="5" fill="#eaeef2"/>
+  <rect x="42" y="492" width="288" height="10" rx="5" fill="url(#barC)"/>
+  <text x="338" y="501" fill="#1a7f37" font-size="11.5" font-weight="700">66.2</text>
+
+  <!-- Col 4: contextBridge -->
+  <text x="512" y="404" fill="#9a6700" font-size="58" font-weight="800" letter-spacing="-0.02em">+28%</text>
+  <text x="514" y="434" fill="#1f2328" font-size="17" font-weight="600">contextBridge calls</text>
+  <text x="514" y="455" fill="#57606a" font-size="13">optimized with Electron's own profile<tspan fill="#8c959f"> &#8224;</tspan></text>
+  <rect x="514" y="472" width="288" height="10" rx="5" fill="#eaeef2"/>
+  <rect x="514" y="472" width="225" height="10" rx="5" fill="#afb8c1"/>
+  <text x="810" y="481" fill="#57606a" font-size="11.5" font-weight="600">baseline</text>
+  <rect x="514" y="492" width="288" height="10" rx="5" fill="#eaeef2"/>
+  <rect x="514" y="492" width="288" height="10" rx="5" fill="url(#barD)"/>
+  <text x="810" y="501" fill="#9a6700" font-size="11.5" font-weight="700">+28%</text>
+
+  <!-- footnotes -->
+  <text x="40" y="530" fill="#8c959f" font-size="10.5">* Sample app, two ~150&#8201;KB preloads, cold launch, Apple Silicon. &#160;&#160;&#8224; Speedometer on MacBook (M5); contextBridge geomean across 13 tests (Linux x64). Numbers vary by hardware.</text>
+</svg>

--- a/static/assets/img/blog/faster-startup-hero-light.svg
+++ b/static/assets/img/blog/faster-startup-hero-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Electron performance improvements. Startup: sandboxed renderer startup drops from about 230 ms to about 130 ms (about 43%); browser-process startup drops from about 125 ms to about 75 ms (about 40%). Runtime: Speedometer 3.1 on an M5 MacBook rises from 56.6 to 66.2 (about 17%); contextBridge calls are about 28% faster overall.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Electron performance improvements. Startup: sandboxed renderer startup drops from about 230 ms to about 130 ms (about 43%); main-process startup drops from about 125 ms to about 75 ms (about 40%). Runtime: Speedometer 3.1 on an M5 MacBook rises from 56.6 to 66.2 (about 17%); contextBridge calls are about 28% faster overall.">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#ffffff"/>
@@ -39,9 +39,9 @@
   <rect x="42" y="262" width="163" height="10" rx="5" fill="url(#barA)"/>
   <text x="338" y="271" fill="#0a7ea4" font-size="11.5" font-weight="700">~130 ms</text>
 
-  <!-- Col 2: browser process -->
+  <!-- Col 2: main process -->
   <text x="512" y="174" fill="#4b59c7" font-size="58" font-weight="800" letter-spacing="-0.02em">~40%</text>
-  <text x="514" y="204" fill="#1f2328" font-size="17" font-weight="600">browser process startup</text>
+  <text x="514" y="204" fill="#1f2328" font-size="17" font-weight="600">main process startup</text>
   <text x="514" y="225" fill="#57606a" font-size="13">Node.js bootstrap from a snapshot<tspan fill="#8c959f"> *</tspan></text>
   <rect x="514" y="242" width="288" height="10" rx="5" fill="#afb8c1"/>
   <text x="810" y="251" fill="#57606a" font-size="11.5" font-weight="600">~125 ms</text>

--- a/static/assets/img/blog/frame-budget-dark.svg
+++ b/static/assets/img/blog/frame-budget-dark.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 300" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="The 60 frames-per-second budget gives an interaction 16.7 milliseconds. Before optimization, an interaction costing 19.7 milliseconds misses the budget and the app drops a frame, which feels janky. After optimization, the same interaction at about 19.5% less CPU costs about 16.4 milliseconds, inside the budget, and the app stays at 60 fps.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#161b22"/><stop offset="1" stop-color="#0d1117"/></linearGradient>
+    <linearGradient id="gOver" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#d29922"/><stop offset="1" stop-color="#da3633"/></linearGradient>
+    <linearGradient id="gIn" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#2ea043"/><stop offset="1" stop-color="#56d364"/></linearGradient>
+  </defs>
+  <rect width="880" height="300" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="299" rx="16" fill="none" stroke="#30363d"/>
+
+  <text x="32" y="44" fill="#e6edf3" font-size="18" font-weight="700">The same interaction, before and after</text>
+
+  <!-- axis: 0 to 24 ms maps to x 110..830 -> 30px per ms -->
+  <!-- budget line at 16.7ms: x = 110 + 16.7*30 = 611 -->
+
+  <!-- ms scale -->
+  <text x="110" y="86" fill="#6e7681" font-size="11">0 ms</text>
+  <text x="260" y="86" fill="#6e7681" font-size="11">5 ms</text>
+  <text x="410" y="86" fill="#6e7681" font-size="11">10 ms</text>
+  <text x="560" y="86" fill="#6e7681" font-size="11">15 ms</text>
+  <text x="710" y="86" fill="#6e7681" font-size="11">20 ms</text>
+  <line x1="110" y1="92" x2="830" y2="92" stroke="#21262d"/>
+
+  <!-- budget line -->
+  <line x1="611" y1="92" x2="611" y2="252" stroke="#e6edf3" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="611" y="276" fill="#e6edf3" font-size="12.5" font-weight="700" text-anchor="middle">16.7 ms</text>
+  <text x="611" y="292" fill="#8b949e" font-size="11" text-anchor="middle">60 fps frame budget</text>
+
+  <!-- BEFORE bar: 19.7ms -> width 591 -->
+  <text x="32" y="130" fill="#8b949e" font-size="12.5" font-weight="600">before</text>
+  <rect x="110" y="114" width="501" height="26" fill="#3d4450"/>
+  <rect x="110" y="114" width="501" height="26" rx="5" fill="#3d4450"/>
+  <rect x="611" y="114" width="90" height="26" fill="url(#gOver)"/>
+  <rect x="611" y="114" width="90" height="26" rx="5" fill="url(#gOver)"/>
+  <rect x="110" y="114" width="591" height="26" rx="5" fill="none" stroke="#0d1117" stroke-width="1"/>
+  <text x="711" y="132" fill="#ff7b72" font-size="13" font-weight="700">19.7 ms</text>
+  <text x="711" y="150" fill="#8b949e" font-size="11.5">misses the frame: <tspan fill="#ff7b72" font-weight="600">janky</tspan></text>
+
+  <!-- AFTER bar: 16.4ms -> width 492 -->
+  <text x="32" y="206" fill="#8b949e" font-size="12.5" font-weight="600">after</text>
+  <rect x="110" y="190" width="492" height="26" fill="url(#gIn)"/>
+  <rect x="110" y="190" width="492" height="26" rx="5" fill="url(#gIn)"/>
+  <text x="612" y="208" fill="#56d364" font-size="13" font-weight="700">16.4 ms</text>
+  <text x="612" y="226" fill="#8b949e" font-size="11.5">inside the budget: <tspan fill="#56d364" font-weight="600">smooth 60 fps</tspan></text>
+
+  <!-- annotation -->
+  <text x="110" y="166" fill="#6e7681" font-size="11.5">~19.5% less CPU for the same work</text>
+</svg>

--- a/static/assets/img/blog/frame-budget-light.svg
+++ b/static/assets/img/blog/frame-budget-light.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 300" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="The 60 frames-per-second budget gives an interaction 16.7 milliseconds. Before optimization, an interaction costing 19.7 milliseconds misses the budget and the app drops a frame, which feels janky. After optimization, the same interaction at about 19.5% less CPU costs about 16.4 milliseconds, inside the budget, and the app stays at 60 fps.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f6f8fa"/></linearGradient>
+    <linearGradient id="gOver" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#bf8700"/><stop offset="1" stop-color="#cf222e"/></linearGradient>
+    <linearGradient id="gIn" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#1a7f37"/><stop offset="1" stop-color="#2da44e"/></linearGradient>
+  </defs>
+  <rect width="880" height="300" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="299" rx="16" fill="none" stroke="#d0d7de"/>
+
+  <text x="32" y="44" fill="#1f2328" font-size="18" font-weight="700">The same interaction, before and after</text>
+
+  <!-- axis: 0 to 24 ms maps to x 110..830 -> 30px per ms -->
+  <!-- budget line at 16.7ms: x = 110 + 16.7*30 = 611 -->
+
+  <!-- ms scale -->
+  <text x="110" y="86" fill="#8c959f" font-size="11">0 ms</text>
+  <text x="260" y="86" fill="#8c959f" font-size="11">5 ms</text>
+  <text x="410" y="86" fill="#8c959f" font-size="11">10 ms</text>
+  <text x="560" y="86" fill="#8c959f" font-size="11">15 ms</text>
+  <text x="710" y="86" fill="#8c959f" font-size="11">20 ms</text>
+  <line x1="110" y1="92" x2="830" y2="92" stroke="#d8dee4"/>
+
+  <!-- budget line -->
+  <line x1="611" y1="92" x2="611" y2="252" stroke="#1f2328" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="611" y="276" fill="#1f2328" font-size="12.5" font-weight="700" text-anchor="middle">16.7 ms</text>
+  <text x="611" y="292" fill="#57606a" font-size="11" text-anchor="middle">60 fps frame budget</text>
+
+  <!-- BEFORE bar: 19.7ms -> width 591 -->
+  <text x="32" y="130" fill="#57606a" font-size="12.5" font-weight="600">before</text>
+  <rect x="110" y="114" width="501" height="26" fill="#afb8c1"/>
+  <rect x="110" y="114" width="501" height="26" rx="5" fill="#afb8c1"/>
+  <rect x="611" y="114" width="90" height="26" fill="url(#gOver)"/>
+  <rect x="611" y="114" width="90" height="26" rx="5" fill="url(#gOver)"/>
+  <rect x="110" y="114" width="591" height="26" rx="5" fill="none" stroke="#ffffff" stroke-width="1"/>
+  <text x="711" y="132" fill="#cf222e" font-size="13" font-weight="700">19.7 ms</text>
+  <text x="711" y="150" fill="#57606a" font-size="11.5">misses the frame: <tspan fill="#cf222e" font-weight="600">janky</tspan></text>
+
+  <!-- AFTER bar: 16.4ms -> width 492 -->
+  <text x="32" y="206" fill="#57606a" font-size="12.5" font-weight="600">after</text>
+  <rect x="110" y="190" width="492" height="26" fill="url(#gIn)"/>
+  <rect x="110" y="190" width="492" height="26" rx="5" fill="url(#gIn)"/>
+  <text x="612" y="208" fill="#1a7f37" font-size="13" font-weight="700">16.4 ms</text>
+  <text x="612" y="226" fill="#57606a" font-size="11.5">inside the budget: <tspan fill="#1a7f37" font-weight="600">smooth 60 fps</tspan></text>
+
+  <!-- annotation -->
+  <text x="110" y="166" fill="#8c959f" font-size="11.5">~19.5% less CPU for the same work</text>
+</svg>

--- a/static/assets/img/blog/pgo-coverage-dark.svg
+++ b/static/assets/img/blog/pgo-coverage-dark.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 400" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="What Chrome's optimization profile covers of the code Electron actually executes. 74.5% matches by name and hash and gets optimized. 19.3% has the same name as a Chrome function but different code, so it is silently rejected. 6.2% does not exist in Chrome's profile at all. In total about a quarter of Electron's executed code gets zero optimization guidance, and that quarter includes Node.js Buffer operations, contextBridge marshaling, Electron's own C++, Skia's SIMD kernels, and V8's JSON stringifier.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#161b22"/><stop offset="1" stop-color="#0d1117"/></linearGradient>
+    <linearGradient id="gOk" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#2ea043"/><stop offset="1" stop-color="#238636"/></linearGradient>
+    <linearGradient id="gRej" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#f0883e"/><stop offset="1" stop-color="#d4691f"/></linearGradient>
+    <linearGradient id="gMiss" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#da3633"/><stop offset="1" stop-color="#b62324"/></linearGradient>
+  </defs>
+  <rect width="880" height="400" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="399" rx="16" fill="none" stroke="#30363d"/>
+
+  <text x="32" y="44" fill="#e6edf3" font-size="18" font-weight="700">What Chrome's profile knows about Electron's code</text>
+  <text x="32" y="68" fill="#8b949e" font-size="13">Share of the code Electron actually executes, by how Chrome's published PGO profile treats it</text>
+
+  <!-- stacked bar: total width 816, 74.5% / 19.3% / 6.2% -->
+  <!-- 816 * .745 = 608 ; 816 * .193 = 157 ; 816 * .062 = 51 -->
+  <rect x="32"  y="96" width="608" height="56" fill="url(#gOk)"/>
+  <rect x="640" y="96" width="157" height="56" fill="url(#gRej)"/>
+  <rect x="797" y="96" width="51"  height="56" fill="url(#gMiss)"/>
+  <rect x="32" y="96" width="816" height="56" rx="8" fill="none" stroke="#0d1117" stroke-width="2"/>
+
+  <!-- in-bar labels -->
+  <text x="52" y="120" fill="#ffffff" font-size="15" font-weight="700">74.5% optimized</text>
+  <text x="52" y="140" fill="#c8e6cd" font-size="12">name + hash match Chrome's</text>
+  <text x="652" y="120" fill="#ffffff" font-size="14" font-weight="700">19.3%</text>
+  <text x="806" y="120" fill="#ffffff" font-size="13" font-weight="700">6.2%</text>
+
+  <!-- callout: rejected -->
+  <line x1="718" y1="152" x2="718" y2="186" stroke="#f0883e" stroke-width="1.5"/>
+  <line x1="718" y1="186" x2="560" y2="186" stroke="#f0883e" stroke-width="1.5"/>
+  <rect x="312" y="170" width="248" height="92" rx="8" fill="#21262d" stroke="#f0883e"/>
+  <text x="330" y="196" fill="#f0883e" font-size="13.5" font-weight="700">Silently rejected</text>
+  <text x="330" y="216" fill="#c9d1d9" font-size="12">Same name, different code:</text>
+  <text x="330" y="234" fill="#8b949e" font-size="12">Skia SIMD raster kernels,</text>
+  <text x="330" y="251" fill="#8b949e" font-size="12">V8's JSON stringifier, Mojo, net</text>
+
+  <!-- callout: missing -->
+  <line x1="822" y1="152" x2="822" y2="206" stroke="#da3633" stroke-width="1.5"/>
+  <line x1="822" y1="206" x2="836" y2="206" stroke="#da3633" stroke-width="0"/>
+  <rect x="588" y="190" width="260" height="92" rx="8" fill="#21262d" stroke="#da3633"/>
+  <line x1="822" y1="152" x2="822" y2="190" stroke="#da3633" stroke-width="1.5"/>
+  <text x="606" y="216" fill="#ff7b72" font-size="13.5" font-weight="700">Not in Chrome's profile at all</text>
+  <text x="606" y="236" fill="#c9d1d9" font-size="12">All of Node.js, contextBridge,</text>
+  <text x="606" y="253" fill="#8b949e" font-size="12">Electron's own C++, libuv</text>
+
+  <!-- bottom takeaway -->
+  <rect x="32" y="296" width="816" height="64" rx="8" fill="#3d1d1d" stroke="#da3633"/>
+  <text x="52" y="323" fill="#ff7b72" font-size="14.5" font-weight="700">One quarter of the code Electron executes gets zero optimization guidance.</text>
+  <text x="52" y="345" fill="#c9d1d9" font-size="12.5">No error, no warning. The compiler just lays it out as cold. Among Electron's 2,000 hottest functions, that quarter carries 23% of all execution.</text>
+
+  <text x="32" y="384" fill="#6e7681" font-size="11">Measured with llvm-profdata: Chrome's published Linux profile vs a profile of Electron running Electron workloads.</text>
+</svg>

--- a/static/assets/img/blog/pgo-coverage-light.svg
+++ b/static/assets/img/blog/pgo-coverage-light.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 400" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="What Chrome's optimization profile covers of the code Electron actually executes. 74.5% matches by name and hash and gets optimized. 19.3% has the same name as a Chrome function but different code, so it is silently rejected. 6.2% does not exist in Chrome's profile at all. In total about a quarter of Electron's executed code gets zero optimization guidance, and that quarter includes Node.js Buffer operations, contextBridge marshaling, Electron's own C++, Skia's SIMD kernels, and V8's JSON stringifier.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f6f8fa"/></linearGradient>
+    <linearGradient id="gOk" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#2da44e"/><stop offset="1" stop-color="#1a7f37"/></linearGradient>
+    <linearGradient id="gRej" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#e16f24"/><stop offset="1" stop-color="#bc4c00"/></linearGradient>
+    <linearGradient id="gMiss" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#cf222e"/><stop offset="1" stop-color="#a40e26"/></linearGradient>
+  </defs>
+  <rect width="880" height="400" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="399" rx="16" fill="none" stroke="#d0d7de"/>
+
+  <text x="32" y="44" fill="#1f2328" font-size="18" font-weight="700">What Chrome's profile knows about Electron's code</text>
+  <text x="32" y="68" fill="#57606a" font-size="13">Share of the code Electron actually executes, by how Chrome's published PGO profile treats it</text>
+
+  <!-- stacked bar: total width 816, 74.5% / 19.3% / 6.2% -->
+  <!-- 816 * .745 = 608 ; 816 * .193 = 157 ; 816 * .062 = 51 -->
+  <rect x="32"  y="96" width="608" height="56" fill="url(#gOk)"/>
+  <rect x="640" y="96" width="157" height="56" fill="url(#gRej)"/>
+  <rect x="797" y="96" width="51"  height="56" fill="url(#gMiss)"/>
+  <rect x="32" y="96" width="816" height="56" rx="8" fill="none" stroke="#ffffff" stroke-width="2"/>
+
+  <!-- in-bar labels -->
+  <text x="52" y="120" fill="#ffffff" font-size="15" font-weight="700">74.5% optimized</text>
+  <text x="52" y="140" fill="#dafbe1" font-size="12">name + hash match Chrome's</text>
+  <text x="652" y="120" fill="#ffffff" font-size="14" font-weight="700">19.3%</text>
+  <text x="806" y="120" fill="#ffffff" font-size="13" font-weight="700">6.2%</text>
+
+  <!-- callout: rejected -->
+  <line x1="718" y1="152" x2="718" y2="186" stroke="#bc4c00" stroke-width="1.5"/>
+  <line x1="718" y1="186" x2="560" y2="186" stroke="#bc4c00" stroke-width="1.5"/>
+  <rect x="312" y="170" width="248" height="92" rx="8" fill="#eaeef2" stroke="#bc4c00"/>
+  <text x="330" y="196" fill="#bc4c00" font-size="13.5" font-weight="700">Silently rejected</text>
+  <text x="330" y="216" fill="#1f2328" font-size="12">Same name, different code:</text>
+  <text x="330" y="234" fill="#57606a" font-size="12">Skia SIMD raster kernels,</text>
+  <text x="330" y="251" fill="#57606a" font-size="12">V8's JSON stringifier, Mojo, net</text>
+
+  <!-- callout: missing -->
+  <line x1="822" y1="152" x2="822" y2="206" stroke="#cf222e" stroke-width="1.5"/>
+  <line x1="822" y1="206" x2="836" y2="206" stroke="#cf222e" stroke-width="0"/>
+  <rect x="588" y="190" width="260" height="92" rx="8" fill="#eaeef2" stroke="#cf222e"/>
+  <line x1="822" y1="152" x2="822" y2="190" stroke="#cf222e" stroke-width="1.5"/>
+  <text x="606" y="216" fill="#cf222e" font-size="13.5" font-weight="700">Not in Chrome's profile at all</text>
+  <text x="606" y="236" fill="#1f2328" font-size="12">All of Node.js, contextBridge,</text>
+  <text x="606" y="253" fill="#57606a" font-size="12">Electron's own C++, libuv</text>
+
+  <!-- bottom takeaway -->
+  <rect x="32" y="296" width="816" height="64" rx="8" fill="#ffebe9" stroke="#cf222e"/>
+  <text x="52" y="323" fill="#cf222e" font-size="14.5" font-weight="700">One quarter of the code Electron executes gets zero optimization guidance.</text>
+  <text x="52" y="345" fill="#1f2328" font-size="12.5">No error, no warning. The compiler just lays it out as cold. Among Electron's 2,000 hottest functions, that quarter carries 23% of all execution.</text>
+
+  <text x="32" y="384" fill="#8c959f" font-size="11">Measured with llvm-profdata: Chrome's published Linux profile vs a profile of Electron running Electron workloads.</text>
+</svg>

--- a/static/assets/img/blog/snapshot-layers-dark.svg
+++ b/static/assets/img/blog/snapshot-layers-dark.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 330" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="The three snapshot layers Electron loads. 1: the V8 startup snapshot (snapshot_blob.bin), V8's read-only heap and a bare context. 2: the Blink context snapshot (v8_context_snapshot.bin), DOM binding templates with zero compiled JavaScript. 3: the Node snapshot (node_snapshot.cc), the bootstrapped Node environment. Only the third captures Node's bootstrap, and it was the one Electron was missing.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#161b22"/><stop offset="1" stop-color="#0d1117"/></linearGradient>
+  </defs>
+  <rect width="880" height="330" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="329" rx="16" fill="none" stroke="#30363d"/>
+
+  <text x="32" y="44" fill="#e6edf3" font-size="18" font-weight="700">Three snapshots, only one holds Node's bootstrap</text>
+
+  <!-- layer 1 -->
+  <rect x="32" y="72" width="816" height="64" rx="8" fill="#21262d" stroke="#30363d"/>
+  <text x="52" y="100" fill="#e6edf3" font-size="15" font-weight="600">V8 startup snapshot <tspan fill="#6e7681" font-weight="400">snapshot_blob.bin</tspan></text>
+  <text x="52" y="122" fill="#8b949e" font-size="12.5">V8's read-only heap and a bare context. Pure V8 internals.</text>
+  <text x="828" y="109" fill="#6e7681" font-size="12" text-anchor="end">already loaded</text>
+
+  <!-- layer 2 -->
+  <rect x="32" y="146" width="816" height="64" rx="8" fill="#21262d" stroke="#30363d"/>
+  <text x="52" y="174" fill="#e6edf3" font-size="15" font-weight="600">Blink context snapshot <tspan fill="#6e7681" font-weight="400">v8_context_snapshot.bin</tspan></text>
+  <text x="52" y="196" fill="#8b949e" font-size="12.5">DOM / Web-IDL binding templates. Zero compiled JavaScript.</text>
+  <text x="828" y="183" fill="#6e7681" font-size="12" text-anchor="end">already loaded</text>
+
+  <!-- layer 3 (the missing one) -->
+  <rect x="32" y="220" width="816" height="64" rx="8" fill="#193a2e" stroke="#3fb950" stroke-width="1.5"/>
+  <text x="52" y="248" fill="#e6edf3" font-size="15" font-weight="600">Node snapshot <tspan fill="#6e7681" font-weight="400">node_snapshot.cc</tspan></text>
+  <text x="52" y="270" fill="#8b949e" font-size="12.5">The bootstrapped Node environment: <tspan fill="#c9d1d9">process</tspan>, primordials, the module loader.</text>
+  <text x="828" y="257" fill="#56d364" font-size="12" font-weight="700" text-anchor="end">the missing piece</text>
+
+  <text x="32" y="312" fill="#6e7681" font-size="11.5">Layers 1 and 2 were always there, but neither captures Node's bootstrap. Layer 3 is the one that does.</text>
+</svg>

--- a/static/assets/img/blog/snapshot-layers-light.svg
+++ b/static/assets/img/blog/snapshot-layers-light.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 330" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="The three snapshot layers Electron loads. 1: the V8 startup snapshot (snapshot_blob.bin), V8's read-only heap and a bare context. 2: the Blink context snapshot (v8_context_snapshot.bin), DOM binding templates with zero compiled JavaScript. 3: the Node snapshot (node_snapshot.cc), the bootstrapped Node environment. Only the third captures Node's bootstrap, and it was the one Electron was missing.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f6f8fa"/></linearGradient>
+  </defs>
+  <rect width="880" height="330" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="329" rx="16" fill="none" stroke="#d0d7de"/>
+
+  <text x="32" y="44" fill="#1f2328" font-size="18" font-weight="700">Three snapshots, only one holds Node's bootstrap</text>
+
+  <!-- layer 1 -->
+  <rect x="32" y="72" width="816" height="64" rx="8" fill="#eaeef2" stroke="#d0d7de"/>
+  <text x="52" y="100" fill="#1f2328" font-size="15" font-weight="600">V8 startup snapshot <tspan fill="#8c959f" font-weight="400">snapshot_blob.bin</tspan></text>
+  <text x="52" y="122" fill="#57606a" font-size="12.5">V8's read-only heap and a bare context. Pure V8 internals.</text>
+  <text x="828" y="109" fill="#8c959f" font-size="12" text-anchor="end">already loaded</text>
+
+  <!-- layer 2 -->
+  <rect x="32" y="146" width="816" height="64" rx="8" fill="#eaeef2" stroke="#d0d7de"/>
+  <text x="52" y="174" fill="#1f2328" font-size="15" font-weight="600">Blink context snapshot <tspan fill="#8c959f" font-weight="400">v8_context_snapshot.bin</tspan></text>
+  <text x="52" y="196" fill="#57606a" font-size="12.5">DOM / Web-IDL binding templates. Zero compiled JavaScript.</text>
+  <text x="828" y="183" fill="#8c959f" font-size="12" text-anchor="end">already loaded</text>
+
+  <!-- layer 3 (the missing one) -->
+  <rect x="32" y="220" width="816" height="64" rx="8" fill="#dafbe1" stroke="#1a7f37" stroke-width="1.5"/>
+  <text x="52" y="248" fill="#1f2328" font-size="15" font-weight="600">Node snapshot <tspan fill="#8c959f" font-weight="400">node_snapshot.cc</tspan></text>
+  <text x="52" y="270" fill="#57606a" font-size="12.5">The bootstrapped Node environment: <tspan fill="#1f2328">process</tspan>, primordials, the module loader.</text>
+  <text x="828" y="257" fill="#1a7f37" font-size="12" font-weight="700" text-anchor="end">the missing piece</text>
+
+  <text x="32" y="312" fill="#8c959f" font-size="11.5">Layers 1 and 2 were always there, but neither captures Node's bootstrap. Layer 3 is the one that does.</text>
+</svg>

--- a/static/assets/img/blog/speedometer-stack-dark.svg
+++ b/static/assets/img/blog/speedometer-stack-dark.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 360" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Speedometer 3.1 scores on an M5 MacBook as each optimization layer is added. Stock Electron scores 56.6. Adding ThinLTO link-time optimization raises it to 59.2, a 5% step. Adding Electron's own C++ PGO profile raises it to 65.5, an 11% step and the largest single gain. Adding Electron's V8 builtins profile raises it to 66.2. Total improvement is about 17%, and the largest step comes from replacing Chrome's borrowed profile with Electron's own.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#161b22"/><stop offset="1" stop-color="#0d1117"/></linearGradient>
+    <linearGradient id="gPgo" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#2ea043"/><stop offset="1" stop-color="#56d364"/></linearGradient>
+  </defs>
+  <rect width="880" height="360" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="359" rx="16" fill="none" stroke="#30363d"/>
+
+  <text x="32" y="44" fill="#e6edf3" font-size="18" font-weight="700">Each layer stacks</text>
+  <text x="32" y="68" fill="#8b949e" font-size="13">Speedometer 3.1, MacBook (M5), identical source</text>
+
+  <!-- bars: x from 32, max width 660 maps to score 70 -> px/score = 9.43 -->
+  <!-- 56.6 -> 534 ; 59.2 -> 558 ; 65.5 -> 618 ; 66.2 -> 624 -->
+
+  <!-- Stock -->
+  <text x="32" y="112" fill="#c9d1d9" font-size="13" font-weight="600">Stock Electron</text>
+  <rect x="32" y="120" width="534" height="22" rx="4" fill="#3d4450"/>
+  <text x="576" y="136" fill="#8b949e" font-size="13" font-weight="700">56.6</text>
+
+  <!-- + ThinLTO -->
+  <text x="32" y="174" fill="#c9d1d9" font-size="13" font-weight="600">+ ThinLTO <tspan fill="#8b949e" font-weight="400">--lto-O2</tspan></text>
+  <rect x="32" y="182" width="534" height="22" rx="4" fill="#3d4450"/>
+  <rect x="566" y="182" width="24" height="22" fill="#7c93f9"/>
+  <rect x="566" y="182" width="24" height="22" rx="4" fill="#7c93f9"/>
+  <text x="600" y="198" fill="#a9b9ff" font-size="13" font-weight="700">59.2 <tspan fill="#8b949e" font-weight="600" font-size="12">(+5%)</tspan></text>
+
+  <!-- + C++ PGO (the big one) -->
+  <text x="32" y="236" fill="#c9d1d9" font-size="13" font-weight="600">+ Electron C++ PGO</text>
+  <rect x="32" y="244" width="534" height="22" rx="4" fill="#3d4450"/>
+  <rect x="566" y="244" width="24" height="22" fill="#7c93f9"/>
+  <rect x="590" y="244" width="59" height="22" fill="url(#gPgo)"/>
+  <rect x="590" y="244" width="59" height="22" rx="4" fill="url(#gPgo)"/>
+  <text x="659" y="260" fill="#56d364" font-size="13" font-weight="700">65.5 <tspan font-size="12">(+11%, the big one)</tspan></text>
+
+  <!-- + V8 builtins PGO -->
+  <text x="32" y="298" fill="#c9d1d9" font-size="13" font-weight="600">+ Electron V8 builtins PGO</text>
+  <rect x="32" y="306" width="534" height="22" rx="4" fill="#3d4450"/>
+  <rect x="566" y="306" width="24" height="22" fill="#7c93f9"/>
+  <rect x="590" y="306" width="59" height="22" fill="url(#gPgo)"/>
+  <rect x="649" y="306" width="7" height="22" fill="#56d364"/>
+  <rect x="649" y="306" width="7" height="22" rx="3" fill="#56d364"/>
+  <text x="666" y="322" fill="#56d364" font-size="13" font-weight="800">66.2</text>
+  <text x="720" y="322" fill="#e6edf3" font-size="13" font-weight="800">+17% total</text>
+
+  <!-- legend strip -->
+  <rect x="32" y="344" width="10" height="10" rx="2" fill="#3d4450"/><text x="48" y="353" fill="#8b949e" font-size="11">stock</text>
+  <rect x="100" y="344" width="10" height="10" rx="2" fill="#7c93f9"/><text x="116" y="353" fill="#8b949e" font-size="11">link-time optimization</text>
+  <rect x="262" y="344" width="10" height="10" rx="2" fill="#56d364"/><text x="278" y="353" fill="#8b949e" font-size="11">Electron's own profiles (the borrowed-data fix)</text>
+</svg>

--- a/static/assets/img/blog/speedometer-stack-light.svg
+++ b/static/assets/img/blog/speedometer-stack-light.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 360" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Speedometer 3.1 scores on an M5 MacBook as each optimization layer is added. Stock Electron scores 56.6. Adding ThinLTO link-time optimization raises it to 59.2, a 5% step. Adding Electron's own C++ PGO profile raises it to 65.5, an 11% step and the largest single gain. Adding Electron's V8 builtins profile raises it to 66.2. Total improvement is about 17%, and the largest step comes from replacing Chrome's borrowed profile with Electron's own.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f6f8fa"/></linearGradient>
+    <linearGradient id="gPgo" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#1a7f37"/><stop offset="1" stop-color="#2da44e"/></linearGradient>
+  </defs>
+  <rect width="880" height="360" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="359" rx="16" fill="none" stroke="#d0d7de"/>
+
+  <text x="32" y="44" fill="#1f2328" font-size="18" font-weight="700">Each layer stacks</text>
+  <text x="32" y="68" fill="#57606a" font-size="13">Speedometer 3.1, MacBook (M5), identical source</text>
+
+  <!-- bars: x from 32, max width 660 maps to score 70 -> px/score = 9.43 -->
+  <!-- 56.6 -> 534 ; 59.2 -> 558 ; 65.5 -> 618 ; 66.2 -> 624 -->
+
+  <!-- Stock -->
+  <text x="32" y="112" fill="#1f2328" font-size="13" font-weight="600">Stock Electron</text>
+  <rect x="32" y="120" width="534" height="22" rx="4" fill="#afb8c1"/>
+  <text x="576" y="136" fill="#57606a" font-size="13" font-weight="700">56.6</text>
+
+  <!-- + ThinLTO -->
+  <text x="32" y="174" fill="#1f2328" font-size="13" font-weight="600">+ ThinLTO <tspan fill="#57606a" font-weight="400">--lto-O2</tspan></text>
+  <rect x="32" y="182" width="534" height="22" rx="4" fill="#afb8c1"/>
+  <rect x="566" y="182" width="24" height="22" fill="#4b59c7"/>
+  <rect x="566" y="182" width="24" height="22" rx="4" fill="#4b59c7"/>
+  <text x="600" y="198" fill="#4b59c7" font-size="13" font-weight="700">59.2 <tspan fill="#57606a" font-weight="600" font-size="12">(+5%)</tspan></text>
+
+  <!-- + C++ PGO (the big one) -->
+  <text x="32" y="236" fill="#1f2328" font-size="13" font-weight="600">+ Electron C++ PGO</text>
+  <rect x="32" y="244" width="534" height="22" rx="4" fill="#afb8c1"/>
+  <rect x="566" y="244" width="24" height="22" fill="#4b59c7"/>
+  <rect x="590" y="244" width="59" height="22" fill="url(#gPgo)"/>
+  <rect x="590" y="244" width="59" height="22" rx="4" fill="url(#gPgo)"/>
+  <text x="659" y="260" fill="#1a7f37" font-size="13" font-weight="700">65.5 <tspan font-size="12">(+11%, the big one)</tspan></text>
+
+  <!-- + V8 builtins PGO -->
+  <text x="32" y="298" fill="#1f2328" font-size="13" font-weight="600">+ Electron V8 builtins PGO</text>
+  <rect x="32" y="306" width="534" height="22" rx="4" fill="#afb8c1"/>
+  <rect x="566" y="306" width="24" height="22" fill="#4b59c7"/>
+  <rect x="590" y="306" width="59" height="22" fill="url(#gPgo)"/>
+  <rect x="649" y="306" width="7" height="22" fill="#1a7f37"/>
+  <rect x="649" y="306" width="7" height="22" rx="3" fill="#1a7f37"/>
+  <text x="666" y="322" fill="#1a7f37" font-size="13" font-weight="800">66.2</text>
+  <text x="720" y="322" fill="#1f2328" font-size="13" font-weight="800">+17% total</text>
+
+  <!-- legend strip -->
+  <rect x="32" y="344" width="10" height="10" rx="2" fill="#afb8c1"/><text x="48" y="353" fill="#57606a" font-size="11">stock</text>
+  <rect x="100" y="344" width="10" height="10" rx="2" fill="#4b59c7"/><text x="116" y="353" fill="#57606a" font-size="11">link-time optimization</text>
+  <rect x="262" y="344" width="10" height="10" rx="2" fill="#1a7f37"/><text x="278" y="353" fill="#57606a" font-size="11">Electron's own profiles (the borrowed-data fix)</text>
+</svg>

--- a/static/assets/img/blog/startup-timeline-dark.svg
+++ b/static/assets/img/blog/startup-timeline-dark.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 430" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Where each optimization lands in startup. The browser process timeline, from spawn to first user JavaScript, has phases for process and Chromium/V8 init, then the Node.js bootstrap, then framework JavaScript. The Node bootstrap shrinks dramatically with the startup snapshot. The sandboxed renderer timeline, from spawn to first paint, has process and Chromium init, preload setup, framework JavaScript compile, and paint. Preload setup shrinks with the one-way Mojo push, and framework JavaScript shrinks with the build-time code cache. Bars are illustrative and not to exact scale.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#161b22"/><stop offset="1" stop-color="#0d1117"/></linearGradient>
+  </defs>
+  <rect width="880" height="430" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="429" rx="16" fill="none" stroke="#30363d"/>
+
+  <text x="32" y="42" fill="#e6edf3" font-size="18" font-weight="700">Where each win lands in startup</text>
+
+  <!-- legend -->
+  <rect x="32" y="58" width="12" height="12" rx="2" fill="#3d4450"/><text x="50" y="68" fill="#8b949e" font-size="11.5">process + Chromium/V8 init</text>
+  <rect x="232" y="58" width="12" height="12" rx="2" fill="#7c93f9"/><text x="250" y="68" fill="#8b949e" font-size="11.5">Node bootstrap</text>
+  <rect x="372" y="58" width="12" height="12" rx="2" fill="#da3633"/><text x="390" y="68" fill="#8b949e" font-size="11.5">preload setup</text>
+  <rect x="500" y="58" width="12" height="12" rx="2" fill="#2ea043"/><text x="518" y="68" fill="#8b949e" font-size="11.5">framework JavaScript</text>
+  <rect x="672" y="58" width="12" height="12" rx="2" fill="#1f6feb"/><text x="690" y="68" fill="#8b949e" font-size="11.5">paint</text>
+
+  <!-- ===== Browser process ===== -->
+  <text x="32" y="104" fill="#e6edf3" font-size="14" font-weight="600">Browser process <tspan fill="#6e7681" font-weight="400" font-size="12.5">· spawn &#8594; first user JavaScript</tspan></text>
+
+  <text x="32" y="132" fill="#6e7681" font-size="11.5">before</text>
+  <rect x="84" y="120" width="120" height="22" rx="3" fill="#3d4450"/>
+  <rect x="206" y="120" width="176" height="22" rx="3" fill="#7c93f9"/>
+  <rect x="384" y="120" width="44"  height="22" rx="3" fill="#2ea043"/>
+
+  <text x="32" y="166" fill="#6e7681" font-size="11.5">after</text>
+  <rect x="84" y="154" width="120" height="22" rx="3" fill="#3d4450"/>
+  <rect x="206" y="154" width="48"  height="22" rx="3" fill="#7c93f9"/>
+  <rect x="256" y="154" width="36"  height="22" rx="3" fill="#2ea043"/>
+  <text x="300" y="170" fill="#a9b9ff" font-size="11" font-weight="600">Node bootstrap restored from snapshot</text>
+
+  <!-- ===== Sandboxed renderer ===== -->
+  <text x="32" y="232" fill="#e6edf3" font-size="14" font-weight="600">Sandboxed renderer <tspan fill="#6e7681" font-weight="400" font-size="12.5">· spawn &#8594; first paint</tspan></text>
+
+  <text x="32" y="260" fill="#6e7681" font-size="11.5">before</text>
+  <rect x="84"  y="248" width="150" height="22" rx="3" fill="#3d4450"/>
+  <rect x="236" y="248" width="300" height="22" rx="3" fill="#da3633"/>
+  <rect x="538" y="248" width="150" height="22" rx="3" fill="#2ea043"/>
+  <rect x="690" y="248" width="44"  height="22" rx="3" fill="#1f6feb"/>
+
+  <text x="32" y="294" fill="#6e7681" font-size="11.5">after</text>
+  <rect x="84"  y="282" width="150" height="22" rx="3" fill="#3d4450"/>
+  <rect x="236" y="282" width="66"  height="22" rx="3" fill="#da3633"/>
+  <rect x="304" y="282" width="104" height="22" rx="3" fill="#2ea043"/>
+  <rect x="410" y="282" width="44"  height="22" rx="3" fill="#1f6feb"/>
+
+  <text x="236" y="326" fill="#f0b3b0" font-size="11" font-weight="600">preload setup pushed, not pulled</text>
+  <text x="304" y="344" fill="#56d364" font-size="11" font-weight="600">framework JS from code cache</text>
+
+  <text x="32" y="392" fill="#8b949e" font-size="12">All three wins are off the critical path between launching your app and seeing its first pixels.</text>
+  <text x="32" y="414" fill="#6e7681" font-size="11">Bars are illustrative and not drawn to exact scale; see the figures above for measured numbers.</text>
+</svg>

--- a/static/assets/img/blog/startup-timeline-dark.svg
+++ b/static/assets/img/blog/startup-timeline-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 430" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Where each optimization lands in startup. The browser process timeline, from spawn to first user JavaScript, has phases for process and Chromium/V8 init, then the Node.js bootstrap, then framework JavaScript. The Node bootstrap shrinks dramatically with the startup snapshot. The sandboxed renderer timeline, from spawn to first paint, has process and Chromium init, preload setup, framework JavaScript compile, and paint. Preload setup shrinks with the one-way Mojo push, and framework JavaScript shrinks with the build-time code cache. Bars are illustrative and not to exact scale.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 430" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Where each optimization lands in startup. The main process timeline, from spawn to first user JavaScript, has phases for process and Chromium/V8 init, then the Node.js bootstrap, then framework JavaScript. The Node bootstrap shrinks dramatically with the startup snapshot. The sandboxed renderer timeline, from spawn to first paint, has process and Chromium init, preload setup, framework JavaScript compile, and paint. Preload setup shrinks with the one-way Mojo push, and framework JavaScript shrinks with the build-time code cache. Bars are illustrative and not to exact scale.">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#161b22"/><stop offset="1" stop-color="#0d1117"/></linearGradient>
   </defs>
@@ -14,8 +14,8 @@
   <rect x="500" y="58" width="12" height="12" rx="2" fill="#2ea043"/><text x="518" y="68" fill="#8b949e" font-size="11.5">framework JavaScript</text>
   <rect x="672" y="58" width="12" height="12" rx="2" fill="#1f6feb"/><text x="690" y="68" fill="#8b949e" font-size="11.5">paint</text>
 
-  <!-- ===== Browser process ===== -->
-  <text x="32" y="104" fill="#e6edf3" font-size="14" font-weight="600">Browser process <tspan fill="#6e7681" font-weight="400" font-size="12.5">· spawn &#8594; first user JavaScript</tspan></text>
+  <!-- ===== Main process ===== -->
+  <text x="32" y="104" fill="#e6edf3" font-size="14" font-weight="600">Main process <tspan fill="#6e7681" font-weight="400" font-size="12.5">· spawn &#8594; first user JavaScript</tspan></text>
 
   <text x="32" y="132" fill="#6e7681" font-size="11.5">before</text>
   <rect x="84" y="120" width="120" height="22" rx="3" fill="#3d4450"/>

--- a/static/assets/img/blog/startup-timeline-light.svg
+++ b/static/assets/img/blog/startup-timeline-light.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 430" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Where each optimization lands in startup. The browser process timeline, from spawn to first user JavaScript, has phases for process and Chromium/V8 init, then the Node.js bootstrap, then framework JavaScript. The Node bootstrap shrinks dramatically with the startup snapshot. The sandboxed renderer timeline, from spawn to first paint, has process and Chromium init, preload setup, framework JavaScript compile, and paint. Preload setup shrinks with the one-way Mojo push, and framework JavaScript shrinks with the build-time code cache. Bars are illustrative and not to exact scale.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f6f8fa"/></linearGradient>
+  </defs>
+  <rect width="880" height="430" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="429" rx="16" fill="none" stroke="#d0d7de"/>
+
+  <text x="32" y="42" fill="#1f2328" font-size="18" font-weight="700">Where each win lands in startup</text>
+
+  <!-- legend -->
+  <rect x="32" y="58" width="12" height="12" rx="2" fill="#afb8c1"/><text x="50" y="68" fill="#57606a" font-size="11.5">process + Chromium/V8 init</text>
+  <rect x="232" y="58" width="12" height="12" rx="2" fill="#4b59c7"/><text x="250" y="68" fill="#57606a" font-size="11.5">Node bootstrap</text>
+  <rect x="372" y="58" width="12" height="12" rx="2" fill="#cf222e"/><text x="390" y="68" fill="#57606a" font-size="11.5">preload setup</text>
+  <rect x="500" y="58" width="12" height="12" rx="2" fill="#1a7f37"/><text x="518" y="68" fill="#57606a" font-size="11.5">framework JavaScript</text>
+  <rect x="672" y="58" width="12" height="12" rx="2" fill="#0969da"/><text x="690" y="68" fill="#57606a" font-size="11.5">paint</text>
+
+  <!-- ===== Browser process ===== -->
+  <text x="32" y="104" fill="#1f2328" font-size="14" font-weight="600">Browser process <tspan fill="#8c959f" font-weight="400" font-size="12.5">· spawn &#8594; first user JavaScript</tspan></text>
+
+  <text x="32" y="132" fill="#8c959f" font-size="11.5">before</text>
+  <rect x="84" y="120" width="120" height="22" rx="3" fill="#afb8c1"/>
+  <rect x="206" y="120" width="176" height="22" rx="3" fill="#4b59c7"/>
+  <rect x="384" y="120" width="44"  height="22" rx="3" fill="#1a7f37"/>
+
+  <text x="32" y="166" fill="#8c959f" font-size="11.5">after</text>
+  <rect x="84" y="154" width="120" height="22" rx="3" fill="#afb8c1"/>
+  <rect x="206" y="154" width="48"  height="22" rx="3" fill="#4b59c7"/>
+  <rect x="256" y="154" width="36"  height="22" rx="3" fill="#1a7f37"/>
+  <text x="300" y="170" fill="#4b59c7" font-size="11" font-weight="600">Node bootstrap restored from snapshot</text>
+
+  <!-- ===== Sandboxed renderer ===== -->
+  <text x="32" y="232" fill="#1f2328" font-size="14" font-weight="600">Sandboxed renderer <tspan fill="#8c959f" font-weight="400" font-size="12.5">· spawn &#8594; first paint</tspan></text>
+
+  <text x="32" y="260" fill="#8c959f" font-size="11.5">before</text>
+  <rect x="84"  y="248" width="150" height="22" rx="3" fill="#afb8c1"/>
+  <rect x="236" y="248" width="300" height="22" rx="3" fill="#cf222e"/>
+  <rect x="538" y="248" width="150" height="22" rx="3" fill="#1a7f37"/>
+  <rect x="690" y="248" width="44"  height="22" rx="3" fill="#0969da"/>
+
+  <text x="32" y="294" fill="#8c959f" font-size="11.5">after</text>
+  <rect x="84"  y="282" width="150" height="22" rx="3" fill="#afb8c1"/>
+  <rect x="236" y="282" width="66"  height="22" rx="3" fill="#cf222e"/>
+  <rect x="304" y="282" width="104" height="22" rx="3" fill="#1a7f37"/>
+  <rect x="410" y="282" width="44"  height="22" rx="3" fill="#0969da"/>
+
+  <text x="236" y="326" fill="#a40e26" font-size="11" font-weight="600">preload setup pushed, not pulled</text>
+  <text x="304" y="344" fill="#1a7f37" font-size="11" font-weight="600">framework JS from code cache</text>
+
+  <text x="32" y="392" fill="#57606a" font-size="12">All three wins are off the critical path between launching your app and seeing its first pixels.</text>
+  <text x="32" y="414" fill="#8c959f" font-size="11">Bars are illustrative and not drawn to exact scale; see the figures above for measured numbers.</text>
+</svg>

--- a/static/assets/img/blog/startup-timeline-light.svg
+++ b/static/assets/img/blog/startup-timeline-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 430" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Where each optimization lands in startup. The browser process timeline, from spawn to first user JavaScript, has phases for process and Chromium/V8 init, then the Node.js bootstrap, then framework JavaScript. The Node bootstrap shrinks dramatically with the startup snapshot. The sandboxed renderer timeline, from spawn to first paint, has process and Chromium init, preload setup, framework JavaScript compile, and paint. Preload setup shrinks with the one-way Mojo push, and framework JavaScript shrinks with the build-time code cache. Bars are illustrative and not to exact scale.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 430" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Where each optimization lands in startup. The main process timeline, from spawn to first user JavaScript, has phases for process and Chromium/V8 init, then the Node.js bootstrap, then framework JavaScript. The Node bootstrap shrinks dramatically with the startup snapshot. The sandboxed renderer timeline, from spawn to first paint, has process and Chromium init, preload setup, framework JavaScript compile, and paint. Preload setup shrinks with the one-way Mojo push, and framework JavaScript shrinks with the build-time code cache. Bars are illustrative and not to exact scale.">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f6f8fa"/></linearGradient>
   </defs>
@@ -14,8 +14,8 @@
   <rect x="500" y="58" width="12" height="12" rx="2" fill="#1a7f37"/><text x="518" y="68" fill="#57606a" font-size="11.5">framework JavaScript</text>
   <rect x="672" y="58" width="12" height="12" rx="2" fill="#0969da"/><text x="690" y="68" fill="#57606a" font-size="11.5">paint</text>
 
-  <!-- ===== Browser process ===== -->
-  <text x="32" y="104" fill="#1f2328" font-size="14" font-weight="600">Browser process <tspan fill="#8c959f" font-weight="400" font-size="12.5">· spawn &#8594; first user JavaScript</tspan></text>
+  <!-- ===== Main process ===== -->
+  <text x="32" y="104" fill="#1f2328" font-size="14" font-weight="600">Main process <tspan fill="#8c959f" font-weight="400" font-size="12.5">· spawn &#8594; first user JavaScript</tspan></text>
 
   <text x="32" y="132" fill="#8c959f" font-size="11.5">before</text>
   <rect x="84" y="120" width="120" height="22" rx="3" fill="#afb8c1"/>

--- a/static/assets/img/blog/sync-ipc-dark.svg
+++ b/static/assets/img/blog/sync-ipc-dark.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 380" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Why a synchronous IPC request that should take 2 ms can take 80 ms. Before: the renderer sends a synchronous request and blocks; the main process is busy with other startup work and keeps yielding, so the cheap reply isn't scheduled until about 78 ms, and only then does the renderer resume. After: the main process pushes the preload bundle one-way during navigation setup, the renderer never blocks, and it resumes at about 22 ms.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#161b22"/><stop offset="1" stop-color="#0d1117"/></linearGradient>
+  </defs>
+  <rect width="880" height="380" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="379" rx="16" fill="none" stroke="#30363d"/>
+
+  <text x="32" y="44" fill="#e6edf3" font-size="18" font-weight="700">Why a 2&#8201;ms request takes 80&#8201;ms</text>
+
+  <!-- ===== BEFORE ===== -->
+  <text x="32" y="78" fill="#f0883e" font-size="13" font-weight="700" letter-spacing="0.08em">BEFORE · SYNCHRONOUS PULL</text>
+
+  <!-- row labels -->
+  <text x="32" y="113" fill="#8b949e" font-size="12.5">main process</text>
+  <text x="32" y="155" fill="#8b949e" font-size="12.5">renderer</text>
+
+  <!-- main process lane: busy chunks of other startup work, reply lands late -->
+  <rect x="150" y="98"  width="120" height="20" rx="3" fill="#3d4450"/>
+  <rect x="276" y="98"  width="120" height="20" rx="3" fill="#3d4450"/>
+  <rect x="402" y="98"  width="110" height="20" rx="3" fill="#3d4450"/>
+  <rect x="518" y="98"  width="100" height="20" rx="3" fill="#3d4450"/>
+  <text x="300" y="91" fill="#6e7681" font-size="11">other startup work (keeps the thread busy)</text>
+  <rect x="624" y="98"  width="22"  height="20" rx="3" fill="#2dd4bf"/>
+  <text x="652" y="113" fill="#9feaf9" font-size="11" font-weight="600">reply (~2&#8201;ms of actual work)</text>
+
+  <!-- renderer lane: blocked the whole time -->
+  <rect x="150" y="140" width="474" height="20" rx="3" fill="#da3633"/>
+  <text x="158" y="155" fill="#ffffff" font-size="11.5" font-weight="600">blocked &#8212; main thread frozen, waiting</text>
+  <rect x="624" y="140" width="216" height="20" rx="3" fill="#21262d"/>
+  <text x="632" y="155" fill="#8b949e" font-size="11.5">resume at ~80&#8201;ms</text>
+
+  <!-- request / reply arrows -->
+  <path d="M 152 140 L 152 120" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arrUp)"/>
+  <path d="M 635 118 L 635 140" stroke="#9feaf9" stroke-width="1.5" marker-end="url(#arrDn)"/>
+  <text x="158" y="134" fill="#8b949e" font-size="10.5">sync request</text>
+
+  <text x="150" y="186" fill="#6e7681" font-size="11.5">The reply is cheap, but it only runs once the main thread finishes everything ahead of it.</text>
+
+  <!-- ===== AFTER ===== -->
+  <text x="32" y="236" fill="#3fb950" font-size="13" font-weight="700" letter-spacing="0.08em">AFTER · ONE-WAY PUSH</text>
+
+  <text x="32" y="271" fill="#8b949e" font-size="12.5">main process</text>
+  <text x="32" y="313" fill="#8b949e" font-size="12.5">renderer</text>
+
+  <!-- main pushes during navigation setup, early -->
+  <rect x="150" y="256" width="120" height="20" rx="3" fill="#2dd4bf"/>
+  <text x="158" y="271" fill="#0d1117" font-size="11" font-weight="700">push bundle</text>
+  <text x="278" y="271" fill="#6e7681" font-size="11">sent during navigation setup, before the renderer needs it</text>
+
+  <!-- renderer never blocks -->
+  <rect x="150" y="298" width="120" height="20" rx="3" fill="#21262d"/>
+  <rect x="276" y="298" width="80" height="20" rx="3" fill="#3fb950"/>
+  <text x="284" y="313" fill="#0d1117" font-size="11" font-weight="700">resume</text>
+  <text x="364" y="313" fill="#56d364" font-size="11.5" font-weight="600">~22&#8201;ms, flat regardless of main-process load</text>
+
+  <!-- push arrow -->
+  <path d="M 210 276 L 210 298" stroke="#2dd4bf" stroke-width="1.5" marker-end="url(#arrDn2)"/>
+
+  <text x="150" y="350" fill="#6e7681" font-size="11.5">No round-trip, no waiting on a busy thread &#8212; the data is already there when the renderer starts.</text>
+
+  <defs>
+    <marker id="arrUp" markerWidth="7" markerHeight="7" refX="3.5" refY="6" orient="auto"><path d="M0,6 L3.5,0 L7,6" fill="#8b949e"/></marker>
+    <marker id="arrDn" markerWidth="7" markerHeight="7" refX="3.5" refY="1" orient="auto"><path d="M0,1 L3.5,7 L7,1" fill="#9feaf9"/></marker>
+    <marker id="arrDn2" markerWidth="7" markerHeight="7" refX="3.5" refY="1" orient="auto"><path d="M0,1 L3.5,7 L7,1" fill="#2dd4bf"/></marker>
+  </defs>
+</svg>

--- a/static/assets/img/blog/sync-ipc-light.svg
+++ b/static/assets/img/blog/sync-ipc-light.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 380" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Why a synchronous IPC request that should take 2 ms can take 80 ms. Before: the renderer sends a synchronous request and blocks; the main process is busy with other startup work and keeps yielding, so the cheap reply isn't scheduled until about 78 ms, and only then does the renderer resume. After: the main process pushes the preload bundle one-way during navigation setup, the renderer never blocks, and it resumes at about 22 ms.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f6f8fa"/></linearGradient>
+  </defs>
+  <rect width="880" height="380" rx="16" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="879" height="379" rx="16" fill="none" stroke="#d0d7de"/>
+
+  <text x="32" y="44" fill="#1f2328" font-size="18" font-weight="700">Why a 2&#8201;ms request takes 80&#8201;ms</text>
+
+  <!-- ===== BEFORE ===== -->
+  <text x="32" y="78" fill="#bc4c00" font-size="13" font-weight="700" letter-spacing="0.08em">BEFORE · SYNCHRONOUS PULL</text>
+
+  <!-- row labels -->
+  <text x="32" y="113" fill="#57606a" font-size="12.5">main process</text>
+  <text x="32" y="155" fill="#57606a" font-size="12.5">renderer</text>
+
+  <!-- main process lane: busy chunks of other startup work, reply lands late -->
+  <rect x="150" y="98"  width="120" height="20" rx="3" fill="#afb8c1"/>
+  <rect x="276" y="98"  width="120" height="20" rx="3" fill="#afb8c1"/>
+  <rect x="402" y="98"  width="110" height="20" rx="3" fill="#afb8c1"/>
+  <rect x="518" y="98"  width="100" height="20" rx="3" fill="#afb8c1"/>
+  <text x="300" y="91" fill="#8c959f" font-size="11">other startup work (keeps the thread busy)</text>
+  <rect x="624" y="98"  width="22"  height="20" rx="3" fill="#0a7ea4"/>
+  <text x="652" y="113" fill="#0a6e8f" font-size="11" font-weight="600">reply (~2&#8201;ms of actual work)</text>
+
+  <!-- renderer lane: blocked the whole time -->
+  <rect x="150" y="140" width="474" height="20" rx="3" fill="#cf222e"/>
+  <text x="158" y="155" fill="#ffffff" font-size="11.5" font-weight="600">blocked &#8212; main thread frozen, waiting</text>
+  <rect x="624" y="140" width="216" height="20" rx="3" fill="#eaeef2"/>
+  <text x="632" y="155" fill="#57606a" font-size="11.5">resume at ~80&#8201;ms</text>
+
+  <!-- request / reply arrows -->
+  <path d="M 152 140 L 152 120" stroke="#57606a" stroke-width="1.5" marker-end="url(#arrUp)"/>
+  <path d="M 635 118 L 635 140" stroke="#0a7ea4" stroke-width="1.5" marker-end="url(#arrDn)"/>
+  <text x="158" y="134" fill="#57606a" font-size="10.5">sync request</text>
+
+  <text x="150" y="186" fill="#8c959f" font-size="11.5">The reply is cheap, but it only runs once the main thread finishes everything ahead of it.</text>
+
+  <!-- ===== AFTER ===== -->
+  <text x="32" y="236" fill="#1a7f37" font-size="13" font-weight="700" letter-spacing="0.08em">AFTER · ONE-WAY PUSH</text>
+
+  <text x="32" y="271" fill="#57606a" font-size="12.5">main process</text>
+  <text x="32" y="313" fill="#57606a" font-size="12.5">renderer</text>
+
+  <!-- main pushes during navigation setup, early -->
+  <rect x="150" y="256" width="120" height="20" rx="3" fill="#0a7ea4"/>
+  <text x="158" y="271" fill="#ffffff" font-size="11" font-weight="700">push bundle</text>
+  <text x="278" y="271" fill="#8c959f" font-size="11">sent during navigation setup, before the renderer needs it</text>
+
+  <!-- renderer never blocks -->
+  <rect x="150" y="298" width="120" height="20" rx="3" fill="#eaeef2"/>
+  <rect x="276" y="298" width="80" height="20" rx="3" fill="#1a7f37"/>
+  <text x="284" y="313" fill="#ffffff" font-size="11" font-weight="700">resume</text>
+  <text x="364" y="313" fill="#1a7f37" font-size="11.5" font-weight="600">~22&#8201;ms, flat regardless of main-process load</text>
+
+  <!-- push arrow -->
+  <path d="M 210 276 L 210 298" stroke="#0a7ea4" stroke-width="1.5" marker-end="url(#arrDn2)"/>
+
+  <text x="150" y="350" fill="#8c959f" font-size="11.5">No round-trip, no waiting on a busy thread &#8212; the data is already there when the renderer starts.</text>
+
+  <defs>
+    <marker id="arrUp" markerWidth="7" markerHeight="7" refX="3.5" refY="6" orient="auto"><path d="M0,6 L3.5,0 L7,6" fill="#57606a"/></marker>
+    <marker id="arrDn" markerWidth="7" markerHeight="7" refX="3.5" refY="1" orient="auto"><path d="M0,1 L3.5,7 L7,1" fill="#0a6e8f"/></marker>
+    <marker id="arrDn2" markerWidth="7" markerHeight="7" refX="3.5" refY="1" orient="auto"><path d="M0,1 L3.5,7 L7,1" fill="#0a7ea4"/></marker>
+  </defs>
+</svg>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8198,6 +8198,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"docusaurus-plugin-image-zoom@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "docusaurus-plugin-image-zoom@npm:3.0.1"
+  dependencies:
+    medium-zoom: "npm:^1.1.0"
+    validate-peer-dependencies: "npm:^2.2.0"
+  peerDependencies:
+    "@docusaurus/theme-classic": ">=3.0.0"
+  checksum: 10c0/c18599f9d29c849fb07baa038fffc0faf5287c3f46546f25af0c60313bfbc36dd9f6176dddd6abd9e332d6a812e8f666e064411395de25dc7ed0e577dbfc5962
+  languageName: node
+  linkType: hard
+
 "docusaurus-plugin-sass@npm:^0.2.1":
   version: 0.2.2
   resolution: "docusaurus-plugin-sass@npm:0.2.2"
@@ -8394,6 +8406,7 @@ __metadata:
     adm-zip: "npm:^0.5.14"
     ajv: "npm:^8.18.0"
     clsx: "npm:^1.1.1"
+    docusaurus-plugin-image-zoom: "npm:^3.0.1"
     docusaurus-plugin-sass: "npm:^0.2.1"
     dotenv: "npm:^16.0.3"
     execa: "npm:^5.0.0"
@@ -12258,6 +12271,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"medium-zoom@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "medium-zoom@npm:1.1.0"
+  checksum: 10c0/7d1f05e8eab045c33d7c04d4ee7bf04f5246cf7a720d7b5f5a51c36ab23666e363bcbb6bffae50b5948d5eb19361914cb0e26a1fce5c1fff7a266bc0217893f3
+  languageName: node
+  linkType: hard
+
 "memfs@npm:^4.43.1":
   version: 4.49.0
   resolution: "memfs@npm:4.49.0"
@@ -13879,6 +13899,22 @@ __metadata:
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 10c0/11ce261f9d294cc7a58d6a574b7f1b935842355ec66fba3c3fd79e0f036462eaf07d0aa95bb74ff432f9afef97ce1926c720988c6a7451d8a584930ae7de86e1
+  languageName: node
+  linkType: hard
+
+"path-root-regex@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "path-root-regex@npm:0.1.2"
+  checksum: 10c0/27651a234f280c70d982dd25c35550f74a4284cde6b97237aab618cb4b5745682d18cdde1160617bb4a4b6b8aec4fbc911c4a2ad80d01fa4c7ee74dae7af2337
+  languageName: node
+  linkType: hard
+
+"path-root@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "path-root@npm:0.1.1"
+  dependencies:
+    path-root-regex: "npm:^0.1.0"
+  checksum: 10c0/aed5cd290df84c46c7730f6a363e95e47a23929b51ab068a3818d69900da3e89dc154cdfd0c45c57b2e02f40c094351bc862db70c2cb00b7e6bd47039a227813
   languageName: node
   linkType: hard
 
@@ -15600,6 +15636,15 @@ __metadata:
   version: 4.0.0
   resolution: "resolve-from@npm:4.0.0"
   checksum: 10c0/8408eec31a3112ef96e3746c37be7d64020cda07c03a920f5024e77290a218ea758b26ca9529fd7b1ad283947f34b2291c1c0f6aa0ed34acfdda9c6014c8d190
+  languageName: node
+  linkType: hard
+
+"resolve-package-path@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "resolve-package-path@npm:4.0.3"
+  dependencies:
+    path-root: "npm:^0.1.1"
+  checksum: 10c0/d2e7883a075b21fbf084f7615f9201e4d5aea6c22ba670dc66503a256c5eba5983d0822b9d51ef33303bfe9b0025916f622f6d780c42d7c020d826f8a9bc58fa
   languageName: node
   linkType: hard
 
@@ -17515,6 +17560,16 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+  languageName: node
+  linkType: hard
+
+"validate-peer-dependencies@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "validate-peer-dependencies@npm:2.2.0"
+  dependencies:
+    resolve-package-path: "npm:^4.0.3"
+    semver: "npm:^7.3.8"
+  checksum: 10c0/0728592b335dbd5d1444019a4e36e34b4de3a8ade5a4970a5f87b40f881dedeff1a00eb3d79add155a4ab3b97c9990d11ed21d8a3d7dccadd129a5bdf5b02a5a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds the blog post **"A Faster Electron"** — a two-part deep dive into the performance work landing across the current PR stack in electron/electron, plus two small site improvements it relies on.

### The post

- **Part one: startup** — moving the sandboxed renderer off synchronous IPC (#51602), a build-time V8 code cache for the `electron/js2c/*` framework bundles (#51697), and a Node.js startup snapshot for the browser process (#51703).
- **Part two: compiler optimization** — enabling ThinLTO `--lto-O2` and replacing Chrome's PGO profiles with Electron-trained ones (#51669 / #51809 / #51812 / #51815).
- Ten theme-responsive SVG diagrams (light/dark variants via `ThemedImage`).

### Site changes

- **`docusaurus-plugin-image-zoom`**: click-to-zoom lightbox for blog images, so the diagrams are readable at full size. Linked images are excluded so they still navigate.
- **Wider blog TOC**: the right sidebar goes from `col--2` (~190 px, wraps almost every heading) to 20%, with the post column giving up the difference.

### Draft because

- The electron/electron PR stack it describes hasn't fully landed yet; publish date should match the release that ships it.
- A few numbers are pending final benchmark runs (browser-process startup ms pair is derived from the measured percentage; noted in the hero footnote).
