### PR TITLE
chore: fetch latest Electron version once per build

### DIFF
--- a/src/transformers/fiddle-embedder.ts
+++ b/src/transformers/fiddle-embedder.ts
@@ -8,15 +8,6 @@ import { visitParents, type ActionTuple, SKIP } from 'unist-util-visit-parents';
 import { latestElectronVersion } from '../util/latest-electron-version.ts';
 import { getJSXImport, isCode, isImport } from '../util/mdx-utils.ts';
 
-let _version = '';
-async function getVersion() {
-  if (_version === '') {
-    _version = await latestElectronVersion();
-  }
-
-  return _version;
-}
-
 export default function attacher() {
   return transformer;
 }
@@ -44,7 +35,7 @@ const importNode = getJSXImport('FiddleEmbed');
 
 async function transformer(tree: Parent) {
   let needImport = false;
-  const version = await getVersion();
+  const version = await latestElectronVersion();
   visitParents(tree, matchFiddleBlock, generateFiddleEmbed);
   visitParents(tree, 'mdxjsEsm', checkForFiddleEmbedImport);
 

--- a/src/transformers/github-content-links.ts
+++ b/src/transformers/github-content-links.ts
@@ -10,15 +10,6 @@ import { isDefinition, isLink } from '../util/mdx-utils.ts';
 const DOCS_FOLDER = path.join(__dirname, '..', '..', 'docs', 'latest');
 const RELATIVE_LINK_REGEX = /^(?:\.\.?\/)+(\S+)$/;
 
-let _version = '';
-async function getVersion() {
-  if (_version === '') {
-    _version = await latestElectronVersion();
-  }
-
-  return _version;
-}
-
 /**
  * `attacher` runs once for the entire plugin's lifetime.
  */
@@ -31,7 +22,7 @@ export default function attacher() {
  * processed by this MDX plugin.
  */
 async function transformer(tree: Parent, vfile: VFile) {
-  const version = await getVersion();
+  const version = await latestElectronVersion();
 
   const findRelativeLinksOutsideDocs = (node: Node) => {
     if (

--- a/src/util/latest-electron-version.ts
+++ b/src/util/latest-electron-version.ts
@@ -1,6 +1,16 @@
 import { ElectronVersions } from '@electron/fiddle-core';
 
+let _latestElectronVersionPromise: Promise<string> | undefined;
+
 export async function latestElectronVersion(): Promise<string> {
-  const versions = await ElectronVersions.create();
-  return versions.latestStable.version;
+  if (_latestElectronVersionPromise) {
+    return _latestElectronVersionPromise;
+  }
+
+  _latestElectronVersionPromise = (async () => {
+    const versions = await ElectronVersions.create();
+    return versions.latestStable.version;
+  })();
+
+  return _latestElectronVersionPromise;
 }


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

Same song and dance as #1055, we want to await a single fetch promise rather than having the Markdown transform fan out kick off a bunch of fetches in parallel, as that's proving flaky.

This hopefully fixes some stability issues we've been seeing with builds in CI.

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
