### PR TITLE
fix(i18n): repair broken API history blocks in translated docs

### DIFF
--- a/scripts/prepare-i18n-content.ts
+++ b/scripts/prepare-i18n-content.ts
@@ -10,8 +10,15 @@ import { logger } from '@docusaurus/logger';
 
 import { addFrontmatterToAllDocs } from './tasks/add-frontmatter.ts';
 import { fixContent } from './tasks/md-fixers.ts';
+import { repairApiHistory } from './tasks/repair-api-history.ts';
+import {
+  type ApiHistoryProblem,
+  logApiHistoryProblems,
+  validateApiHistory,
+} from './tasks/validate-api-history.ts';
 
 const DOCS_FOLDER = path.join('docs', 'latest');
+const API_HISTORY_SCHEMA = path.join(DOCS_FOLDER, 'api-history.schema.json');
 
 const start = async () => {
   // TODO(dsanders11): This is a nasty hack to get around
@@ -35,6 +42,9 @@ const start = async () => {
     ),
   );
   locales.delete('en');
+
+  const apiHistoryProblems: ApiHistoryProblem[] = [];
+
   for (const locale of locales) {
     const localeDocs = path.join(
       'i18n',
@@ -58,6 +68,34 @@ const start = async () => {
 
     logger.info(`Adding automatic frontmatter (${logger.green(locale)})`);
     await addFrontmatterToAllDocs(path.join(localeDocs, 'latest'));
+
+    logger.info(
+      `Repairing broken API history blocks (${logger.green(locale)})`,
+    );
+    const { repaired } = await repairApiHistory(
+      path.join(localeDocs, 'latest'),
+      DOCS_FOLDER,
+      API_HISTORY_SCHEMA,
+    );
+    logger.info(
+      `Repaired ${logger.green(String(repaired))} API history block(s) (${logger.green(locale)})`,
+    );
+
+    logger.info(`Validating API history blocks (${logger.green(locale)})`);
+    apiHistoryProblems.push(
+      ...(await validateApiHistory(localeDocs, API_HISTORY_SCHEMA, 'latest')),
+    );
+  }
+
+  // Repaired blocks are valid by construction, so anything left is a broken
+  // block we could not match to an English one. It would otherwise only fail
+  // much later as an opaque `Invalid API history YAML` from inside the MDX
+  // loader, so fail here with the offending files instead.
+  if (apiHistoryProblems.length > 0) {
+    logApiHistoryProblems(apiHistoryProblems);
+    throw new Error(
+      `Found ${apiHistoryProblems.length} invalid API history block(s) in the translated content`,
+    );
   }
 };
 

--- a/scripts/tasks/repair-api-history.ts
+++ b/scripts/tasks/repair-api-history.ts
@@ -1,0 +1,200 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { logger } from '@docusaurus/logger';
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import { visit } from 'unist-util-visit';
+
+import {
+  type ApiHistoryProblem,
+  type ApiHistoryValidator,
+  compileApiHistorySchema,
+  getApiHistoryBlockProblem,
+  matchApiHistoryCodeBlock,
+} from './validate-api-history.ts';
+
+import type { Code, Root } from 'mdast';
+
+const PR_URL_REGEX = /https:\/\/github\.com\/electron\/electron\/pull\/\d+/g;
+
+export interface RepairApiHistoryResult {
+  repaired: number;
+  unrepaired: ApiHistoryProblem[];
+}
+
+const findApiHistoryBlocks = (content: string) => {
+  const blocks: Code[] = [];
+
+  visit(fromMarkdown(content) as Root, matchApiHistoryCodeBlock, (node) => {
+    blocks.push(node);
+  });
+
+  return blocks;
+};
+
+/**
+ * The PR URLs of a block, which are never translated, so they identify
+ * a block even when the surrounding content is in another language.
+ * @param block
+ */
+const getSignature = (block: Code) =>
+  (block.value.match(PR_URL_REGEX) ?? []).join(',');
+
+/**
+ * The block as it is written in the document, fence included.
+ * @param content
+ * @param block
+ */
+const getRawBlock = (content: string, block: Code) => {
+  const { start, end } = block.position!;
+  return content.slice(start.offset!, end.offset!);
+};
+
+/**
+ * Finds the English counterpart of a translated block: by PR URLs first,
+ * falling back to the position of the block in the document when a
+ * translation mangled them.
+ * @param block
+ * @param index
+ * @param englishBlocks
+ * @param translatedBlockCount
+ */
+const findEnglishBlock = (
+  block: Code,
+  index: number,
+  englishBlocks: Code[],
+  translatedBlockCount: number,
+) => {
+  const signature = getSignature(block);
+
+  if (signature !== '') {
+    const matches = englishBlocks.filter(
+      (englishBlock) => getSignature(englishBlock) === signature,
+    );
+
+    // Only trust the signature when it is unambiguous
+    if (matches.length === 1) {
+      return matches[0];
+    }
+  }
+
+  if (englishBlocks.length === translatedBlockCount) {
+    return englishBlocks[index];
+  }
+
+  return undefined;
+};
+
+const repairFile = async (
+  filePath: string,
+  englishFilePath: string,
+  validateAgainstSchema?: ApiHistoryValidator,
+): Promise<RepairApiHistoryResult> => {
+  const content = await fs.readFile(filePath, 'utf-8');
+
+  if (!content.includes('```')) return { repaired: 0, unrepaired: [] };
+
+  const blocks = findApiHistoryBlocks(content);
+
+  if (blocks.length === 0) return { repaired: 0, unrepaired: [] };
+
+  // Only the broken blocks need touching, so don't read the English file until
+  // we know there is something to repair
+  const brokenBlocks = blocks
+    .map((block, index) => ({
+      block,
+      index,
+      reason: getApiHistoryBlockProblem(block, validateAgainstSchema),
+    }))
+    .filter(({ reason }) => reason !== undefined);
+
+  if (brokenBlocks.length === 0) return { repaired: 0, unrepaired: [] };
+
+  const toProblem = ({ block, reason }: (typeof brokenBlocks)[number]) => ({
+    filePath,
+    line: block.position!.start.line,
+    reason: reason!,
+    block: block.value,
+  });
+
+  let englishContent: string;
+
+  try {
+    englishContent = await fs.readFile(englishFilePath, 'utf-8');
+  } catch {
+    logger.warn(
+      `No English counterpart for ${logger.green(filePath)}, cannot repair its API history blocks`,
+    );
+    return { repaired: 0, unrepaired: brokenBlocks.map(toProblem) };
+  }
+
+  const englishBlocks = findApiHistoryBlocks(englishContent);
+
+  let repaired = 0;
+  const unrepaired: ApiHistoryProblem[] = [];
+  let newContent = content;
+
+  // Replace back to front so the positions of the earlier blocks hold
+  for (const brokenBlock of [...brokenBlocks].reverse()) {
+    const { block, index } = brokenBlock;
+    const englishBlock = findEnglishBlock(
+      block,
+      index,
+      englishBlocks,
+      blocks.length,
+    );
+
+    if (englishBlock === undefined) {
+      unrepaired.push(toProblem(brokenBlock));
+      continue;
+    }
+
+    newContent =
+      newContent.slice(0, block.position!.start.offset!) +
+      getRawBlock(englishContent, englishBlock) +
+      newContent.slice(block.position!.end.offset!);
+    repaired++;
+  }
+
+  if (newContent !== content) {
+    await fs.writeFile(filePath, newContent, 'utf-8');
+  }
+
+  return { repaired, unrepaired };
+};
+
+/**
+ * The structure of an API history block (its keys, PR URLs and
+ * `breaking-changes-header` values) must stay in English or it breaks the
+ * `api-history` transformer at build time, while its `description` values are
+ * rendered to readers and are worth translating. So replace a block with its
+ * English counterpart only when the translation has actually broken it, which
+ * leaves translated descriptions in place everywhere else.
+ * @param root The translated docs folder, e.g. `i18n/es/docusaurus-plugin-content-docs/current/latest`
+ * @param englishRoot The English docs folder the translations were made from, e.g. `docs/latest`
+ * @param schemaPath The **English** `api-history.schema.json`
+ */
+export const repairApiHistory = async (
+  root: string,
+  englishRoot: string,
+  schemaPath: string,
+): Promise<RepairApiHistoryResult> => {
+  const validateAgainstSchema = await compileApiHistorySchema(schemaPath);
+  const files = fs.glob('**/*.md', { cwd: root });
+
+  let repaired = 0;
+  const unrepaired: ApiHistoryProblem[] = [];
+
+  for await (const filePath of files) {
+    const result = await repairFile(
+      path.join(root, filePath),
+      path.join(englishRoot, filePath),
+      validateAgainstSchema,
+    );
+
+    repaired += result.repaired;
+    unrepaired.push(...result.unrepaired);
+  }
+
+  return { repaired, unrepaired };
+};

--- a/scripts/tasks/validate-api-history.ts
+++ b/scripts/tasks/validate-api-history.ts
@@ -1,0 +1,212 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { logger } from '@docusaurus/logger';
+import Ajv, { type ValidateFunction } from 'ajv';
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import { visit } from 'unist-util-visit';
+import { parse as parseYaml } from 'yaml';
+
+import { isCode } from '../../src/util/mdx-utils.ts';
+
+import type { Code, Root } from 'mdast';
+import type { Node } from 'unist';
+
+interface ChangeSchema {
+  'pr-url': string;
+  'breaking-changes-header'?: string;
+  description?: string;
+}
+
+interface ApiHistory {
+  added?: ChangeSchema[];
+  deprecated?: ChangeSchema[];
+  changes?: ChangeSchema[];
+}
+
+export type ApiHistoryValidator = ValidateFunction<ApiHistory>;
+
+export interface ApiHistoryProblem {
+  filePath: string;
+  line: number;
+  reason: string;
+  block: string;
+}
+
+/**
+ * Same predicate the `api-history` remark transformer uses to pick up
+ * blocks at build time, so we only flag blocks which can break the build.
+ * See `src/transformers/api-history.ts`.
+ */
+export function matchApiHistoryCodeBlock(node: Node): node is Code {
+  return (
+    isCode(node) &&
+    node.lang?.toLowerCase() === 'yaml' &&
+    node.meta?.toLowerCase() === 'history'
+  );
+}
+
+function isObject(
+  value: unknown,
+): value is Record<string | number | symbol, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Same shape check as `src/transformers/api-history.ts`, which throws
+ * `Invalid API history YAML` from inside the MDX loader when it fails.
+ */
+function isApiHistory(value: unknown): value is ApiHistory {
+  return (
+    isObject(value) &&
+    ('added' in value || 'deprecated' in value || 'changes' in value)
+  );
+}
+
+/**
+ * `description` is the one part of a history block we want translated, and a
+ * translation is regularly longer than the source it came from. The 120
+ * character cap is a style rule for the English docs, not something the site
+ * needs, so drop it rather than reject a good translation over its length.
+ * @param schema
+ */
+const allowLongDescriptions = (schema: Record<string, unknown>) => {
+  const definitions = schema['definitions'];
+  if (!isObject(definitions)) return;
+
+  const baseChangeSchema = definitions['baseChangeSchema'];
+  if (!isObject(baseChangeSchema)) return;
+
+  const properties = baseChangeSchema['properties'];
+  if (!isObject(properties)) return;
+
+  const description = properties['description'];
+  if (!isObject(description)) return;
+
+  delete description['maxLength'];
+};
+
+/**
+ * Compiles the API history JSON schema.
+ *
+ * Note this must always be the English schema: Crowdin translates the
+ * localized copies of `api-history.schema.json` (`"type": "objeto"`), which
+ * makes them useless for validation.
+ * @param schemaPath
+ */
+export const compileApiHistorySchema = async (schemaPath: string) => {
+  try {
+    const ajv = new Ajv();
+    const apiHistorySchemaFile = await fs.readFile(schemaPath, 'utf-8');
+    const apiHistorySchema = JSON.parse(apiHistorySchemaFile) as Record<
+      string,
+      unknown
+    >;
+    allowLongDescriptions(apiHistorySchema);
+    return ajv.compile<ApiHistory>(apiHistorySchema);
+  } catch (error) {
+    logger.warn(
+      `Error reading API history schema, continuing without schema validation:\n${error}`,
+    );
+    return undefined;
+  }
+};
+
+/**
+ * Checks a single block, and returns why it is invalid, or `undefined` when
+ * there is nothing wrong with it.
+ * @param block
+ * @param validateAgainstSchema
+ */
+export const getApiHistoryBlockProblem = (
+  block: Code,
+  validateAgainstSchema?: ApiHistoryValidator,
+): string | undefined => {
+  let apiHistory: unknown;
+
+  try {
+    apiHistory = parseYaml(block.value);
+  } catch (error) {
+    return `YAML could not be parsed: ${(error as Error).message}`;
+  }
+
+  // This is the check which fails the build in the `api-history` transformer
+  if (!isApiHistory(apiHistory)) {
+    return 'YAML has none of the `added`, `deprecated` or `changes` keys (were they translated?)';
+  }
+
+  if (validateAgainstSchema && !validateAgainstSchema(apiHistory)) {
+    const details = (validateAgainstSchema.errors ?? [])
+      .map((error) => `${error.instancePath || '/'} ${error.message}`)
+      .join(', ');
+    return `YAML does not match the API history schema: ${details}`;
+  }
+
+  return undefined;
+};
+
+const getProblemsInFile = (
+  filePath: string,
+  content: string,
+  validateAgainstSchema?: ApiHistoryValidator,
+) => {
+  const problems: ApiHistoryProblem[] = [];
+
+  visit(fromMarkdown(content) as Root, matchApiHistoryCodeBlock, (node) => {
+    const reason = getApiHistoryBlockProblem(node, validateAgainstSchema);
+
+    if (reason !== undefined) {
+      problems.push({
+        filePath,
+        line: node.position?.start.line ?? 0,
+        reason,
+        block: node.value,
+      });
+    }
+  });
+
+  return problems;
+};
+
+/**
+ * Finds API history blocks a translation has broken. Those only blow up deep
+ * inside the MDX loader at build time, so find them here instead.
+ * @param root The docs folder to check, e.g. `i18n/es/docusaurus-plugin-content-docs/current`
+ * @param schemaPath The **English** `api-history.schema.json`
+ * @param version
+ */
+export const validateApiHistory = async (
+  root: string,
+  schemaPath: string,
+  version = 'latest',
+) => {
+  const validateAgainstSchema = await compileApiHistorySchema(schemaPath);
+
+  const files = fs.glob(`${version}/**/*.md`, { cwd: root });
+  const problems: ApiHistoryProblem[] = [];
+
+  for await (const filePath of files) {
+    const fullFilePath = path.join(root, filePath);
+    const content = await fs.readFile(fullFilePath, 'utf-8');
+
+    if (!content.includes('```')) continue;
+
+    problems.push(
+      ...getProblemsInFile(fullFilePath, content, validateAgainstSchema),
+    );
+  }
+
+  return problems;
+};
+
+/**
+ * Logs the problems found by {@link validateApiHistory}.
+ * @param problems
+ */
+export const logApiHistoryProblems = (problems: ApiHistoryProblem[]) => {
+  for (const { filePath, line, reason, block } of problems) {
+    logger.error(
+      `Invalid API history block in ${logger.green(`${filePath}:${line}`)}: ${reason}\n${block}`,
+    );
+  }
+};


### PR DESCRIPTION
## Why

The "Update i18n deploy" workflow keeps failing with an opaque error when a translator translates part of a `YAML history` block. Most recent occurrence ([run 30285891448](https://github.com/electron/website/actions/runs/30285891448)):

```
Error: MDX compilation failed for file ".../i18n/es/docusaurus-plugin-content-docs/current/latest/api/content-tracing.md"
Cause: Invalid API history YAML
    at maybeGenerateApiHistoryTable (.../src/transformers/api-history.ts:204:15)
```

The cause was `cambios:` in the Spanish copy where the English source has `changes:`, so `isApiHistory()` rejects it and the build dies inside the MDX loader with no file/line for the actual block.

Crowdin exposes these blocks as translatable strings (the committed `docs/latest` content has them uncommented, so `yarn i18n:upload` sends them as translatable Markdown), and `i18n/` is regenerated on every deploy — so a local edit can't fix this and it will recur. This fixes it where the localized content is generated.

## What

Two new tasks, wired into `scripts/prepare-i18n-content.ts` (the second half of `yarn i18n:download`) per locale:

- **`repairApiHistory()`** replaces a translated block with its English counterpart — but *only* when the block genuinely fails: unparseable YAML, none of `added`/`deprecated`/`changes`, or a schema violation. Valid blocks are untouched, so translated `description` values survive; only the structure (keys, `pr-url`, `breaking-changes-header`) has to stay English. English blocks are matched by PR-URL signature (URLs are never translated), falling back to block position.
- **`validateApiHistory()`** re-checks everything afterwards and throws with `file:line` plus a reason. Anything the repair can't match now fails the download with a usable message instead of failing the build with a stack trace.

Two details worth flagging for review:

- Validation always compiles the **English** `docs/latest/api-history.schema.json`. The localized copies are themselves translated — they contain `"type": "objeto"` / `"arreglo"` — and can't be used.
- It drops the schema's `description` `maxLength: 120` for translated content. That cap is a style rule for the English docs, and a translation is routinely longer than its source, so enforcing it would revert perfectly good translations.

## Testing

Against a fresh `yarn i18n:download` (2026-07-27):

- 0 invalid blocks across all seven locales.
- The four descriptions translated into Spanish on 2026-07-24 in `api/content-tracing.md` are **preserved**; the broken `cambios:` block falls back to English.
- Fixture checks: a 165-character Spanish description (over the old 120 cap) is preserved; both `cambios:` and a `descripción:` field-name break are repaired.
- `yarn docusaurus build --locale es` exits 0 — no `Invalid API history YAML`. (Pre-existing broken-anchor warnings remain, unrelated.)
- `tsc --noEmit`, `oxfmt --check scripts/` and `oxlint` all clean.

Not addressed here: the broken translation still exists in Crowdin, so it comes back on every download and this step keeps repairing it. Fixing it upstream is a separate, manual per-string action.

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>