### PR TITLE
Remove Redundant GitHub Admonitions Plugin

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -6,9 +6,6 @@ import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import npm2yarn from '@docusaurus/remark-plugin-npm2yarn';
 import { themes as prismThemes } from 'prism-react-renderer';
-import remarkGithubAdmonitionsToDirectives, {
-  DEFAULT_MAPPING,
-} from 'remark-github-admonitions-to-directives';
 
 import apiLabels from './src/transformers/api-labels.ts';
 import apiOptionsClass from './src/transformers/api-options-class.ts';
@@ -280,14 +277,6 @@ const config: Config = {
       {
         docs: {
           path: 'docs',
-          beforeDefaultRemarkPlugins: [
-            [
-              remarkGithubAdmonitionsToDirectives,
-              {
-                mapping: DEFAULT_MAPPING,
-              },
-            ],
-          ],
           sidebarPath: require.resolve('./sidebars.js'),
           routeBasePath: '/docs/',
           editUrl: ({ docPath }) => {
@@ -308,7 +297,6 @@ const config: Config = {
         blog: {
           // See `node_modules/@docusaurus/plugin-content-blog/src/pluginOptionSchema.ts` for full undocumented options
           path: 'blog',
-          beforeDefaultRemarkPlugins: [remarkGithubAdmonitionsToDirectives],
           blogSidebarCount: 'ALL',
           blogSidebarTitle: 'Latest posts',
           blogTitle: `Electron's blog`,

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.1",
     "react-useportal": "^1.0.14",
-    "remark-github-admonitions-to-directives": "^2.0.0",
     "sass": "^1.37.5",
     "semver": "^7.5.4",
     "yaml": "^2.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8590,7 +8590,6 @@ __metadata:
     react-useportal: "npm:^1.0.14"
     remark: "npm:^15.0.0"
     remark-gfm: "npm:^4.0.0"
-    remark-github-admonitions-to-directives: "npm:^2.0.0"
     sass: "npm:^1.37.5"
     satori: "npm:^0.25.0"
     semver: "npm:^7.5.4"
@@ -15653,18 +15652,6 @@ __metadata:
     remark-stringify: "npm:^11.0.0"
     unified: "npm:^11.0.0"
   checksum: 10c0/db0aa85ab718d475c2596e27c95be9255d3b0fc730a4eda9af076b919f7dd812f7be3ac020611a8dbe5253fd29671d7b12750b56e529fdc32dfebad6dbf77403
-  languageName: node
-  linkType: hard
-
-"remark-github-admonitions-to-directives@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "remark-github-admonitions-to-directives@npm:2.1.0"
-  dependencies:
-    "@types/mdast": "npm:^4.0.0"
-    mdast-util-directive: "npm:^3.0.0"
-    unified: "npm:^11.0.0"
-    unist-util-visit: "npm:^5.0.0"
-  checksum: 10c0/63f82349eff26d28228f0d19af6bcb423fe95e71959f0485ace882cd9e3d6c645ae4a2dab093877339885da5934baf1d658653fe8aba44f65156c3ef94524a45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Removed `remark-github-admonitions-to-directives` since Docusaurus 3+ natively supports GitHub-flavored alerts.

## Changes

- Removed the plugin from `docusaurus.config.ts`.
- Removed `remark-github-admonitions-to-directives` from dependencies.
- Updated `package.json` and `yarn.lock`.

## Impact

- Avoids potential Markdown rendering conflicts.
- Simplifies the Docusaurus configuration.
- Reduces unnecessary dependency and build overhead.

## Testing

Verified that the project continues to use Docusaurus's native GitHub alert support.

## Closes #1189 